### PR TITLE
Add core `Generation`, `Population` and `Individual` traits

### DIFF
--- a/packages/brace-ec/src/core/generation.rs
+++ b/packages/brace-ec/src/core/generation.rs
@@ -1,0 +1,45 @@
+use super::population::Population;
+
+pub trait Generation {
+    type Id;
+    type Population: Population;
+
+    fn id(&self) -> &Self::Id;
+
+    fn population(&self) -> &Self::Population;
+}
+
+impl<T, P> Generation for (T, P)
+where
+    P: Population,
+{
+    type Id = T;
+    type Population = P;
+
+    fn id(&self) -> &Self::Id {
+        &self.0
+    }
+
+    fn population(&self) -> &Self::Population {
+        &self.1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::population::Population;
+
+    use super::Generation;
+
+    fn erase<T, G: Generation<Id = T>>(generation: G) -> impl Generation<Id = T> {
+        generation
+    }
+
+    #[test]
+    fn test_generation_tuple() {
+        let generation = erase((0, [[0, 0]]));
+
+        assert_eq!(generation.id(), &0);
+        assert_eq!(generation.population().len(), 1);
+    }
+}

--- a/packages/brace-ec/src/core/individual.rs
+++ b/packages/brace-ec/src/core/individual.rs
@@ -1,0 +1,44 @@
+pub trait Individual {
+    type Genome: ?Sized;
+
+    fn genome(&self) -> &Self::Genome;
+}
+
+impl<T, const N: usize> Individual for [T; N] {
+    type Genome = [T];
+
+    fn genome(&self) -> &Self::Genome {
+        self
+    }
+}
+
+impl<T> Individual for Vec<T> {
+    type Genome = [T];
+
+    fn genome(&self) -> &Self::Genome {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Individual;
+
+    fn erase<G: ?Sized, I: Individual<Genome = G>>(individual: I) -> impl Individual<Genome = G> {
+        individual
+    }
+
+    #[test]
+    fn test_individual_array() {
+        let individual = erase([0, 0]);
+
+        assert_eq!(individual.genome(), [0, 0]);
+    }
+
+    #[test]
+    fn test_individual_vec() {
+        let individual = erase(vec![0, 0]);
+
+        assert_eq!(individual.genome(), [0, 0]);
+    }
+}

--- a/packages/brace-ec/src/core/mod.rs
+++ b/packages/brace-ec/src/core/mod.rs
@@ -1,0 +1,3 @@
+pub mod generation;
+pub mod individual;
+pub mod population;

--- a/packages/brace-ec/src/core/population.rs
+++ b/packages/brace-ec/src/core/population.rs
@@ -1,0 +1,73 @@
+use super::individual::Individual;
+
+pub trait Population {
+    type Individual: Individual;
+
+    fn len(&self) -> usize;
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl<T, const N: usize> Population for [T; N]
+where
+    T: Individual,
+{
+    type Individual = T;
+
+    fn len(&self) -> usize {
+        self.as_slice().len()
+    }
+}
+
+impl<T> Population for Vec<T>
+where
+    T: Individual,
+{
+    type Individual = T;
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Population;
+
+    fn erase<P: Population>(population: P) -> impl Population {
+        population
+    }
+
+    #[test]
+    fn test_population_array() {
+        let population = erase([[0, 0]]);
+
+        assert!(!population.is_empty());
+        assert_eq!(population.len(), 1);
+
+        let population = erase([[0, 0], [1, 1]]);
+
+        assert!(!population.is_empty());
+        assert_eq!(population.len(), 2);
+    }
+
+    #[test]
+    fn test_population_vec() {
+        let population = erase(Vec::<[u32; 2]>::new());
+
+        assert!(population.is_empty());
+        assert_eq!(population.len(), 0);
+
+        let population = erase(vec![[0, 0]]);
+
+        assert!(!population.is_empty());
+        assert_eq!(population.len(), 1);
+
+        let population = erase(vec![[0, 0], [1, 1]]);
+
+        assert!(!population.is_empty());
+        assert_eq!(population.len(), 2);
+    }
+}

--- a/packages/brace-ec/src/lib.rs
+++ b/packages/brace-ec/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod core;


### PR DESCRIPTION
This adds the `core` module with the `Generation`, `Population` and `Individual` traits.

The foundation of evolutionary computation is the idea of evolving populations of candidate solutions (individuals) over multiple generations by applying an algorithm. This encapsulates those concepts as traits.

This change includes the `Generation`, `Population` and `Individual` traits as well as some simple implementations and relevant tests to ensure that the methods are correct. At the moment these are fairly trivial and have little interaction but they do form the basis of the project moving forward. The tests mostly exist to ensure that the `Population::len` method does not unintentionally recurse.