### PR TITLE
Add `IterablePopulation` utility trait

### DIFF
--- a/packages/brace-ec/src/core/population.rs
+++ b/packages/brace-ec/src/core/population.rs
@@ -1,3 +1,5 @@
+use crate::util::iter::Iterable;
+
 use super::individual::Individual;
 
 pub trait Population {
@@ -32,11 +34,26 @@ where
     }
 }
 
+pub trait IterablePopulation: Population + Iterable<Item = Self::Individual> {}
+
+impl<T> IterablePopulation for T where T: Population + Iterable<Item = Self::Individual> {}
+
 #[cfg(test)]
 mod tests {
-    use super::Population;
+    use crate::core::individual::Individual;
+    use crate::util::iter::Iterable;
+
+    use super::{IterablePopulation, Population};
 
     fn erase<P: Population>(population: P) -> impl Population {
+        population
+    }
+
+    fn erase_iter<I, P>(population: P) -> impl IterablePopulation<Individual = I>
+    where
+        I: Individual,
+        P: IterablePopulation<Individual = I>,
+    {
         population
     }
 
@@ -51,6 +68,15 @@ mod tests {
 
         assert!(!population.is_empty());
         assert_eq!(population.len(), 2);
+
+        let population = erase_iter([[0], [1], [2]]);
+
+        let mut iter = population.iter();
+
+        assert_eq!(iter.next(), Some(&[0]));
+        assert_eq!(iter.next(), Some(&[1]));
+        assert_eq!(iter.next(), Some(&[2]));
+        assert_eq!(iter.next(), None);
     }
 
     #[test]
@@ -69,5 +95,14 @@ mod tests {
 
         assert!(!population.is_empty());
         assert_eq!(population.len(), 2);
+
+        let population = erase_iter(vec![[0], [1], [2]]);
+
+        let mut iter = population.iter();
+
+        assert_eq!(iter.next(), Some(&[0]));
+        assert_eq!(iter.next(), Some(&[1]));
+        assert_eq!(iter.next(), Some(&[2]));
+        assert_eq!(iter.next(), None);
     }
 }

--- a/packages/brace-ec/src/lib.rs
+++ b/packages/brace-ec/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod core;
+pub mod util;

--- a/packages/brace-ec/src/util/iter.rs
+++ b/packages/brace-ec/src/util/iter.rs
@@ -1,0 +1,35 @@
+pub trait Iterable {
+    type Item;
+
+    type Iter<'a>: Iterator<Item = &'a Self::Item>
+    where
+        Self: 'a;
+
+    fn iter(&self) -> Self::Iter<'_>;
+}
+
+impl<const N: usize, T> Iterable for [T; N] {
+    type Item = T;
+
+    type Iter<'a>
+        = std::slice::Iter<'a, T>
+    where
+        T: 'a;
+
+    fn iter(&self) -> Self::Iter<'_> {
+        self.as_slice().iter()
+    }
+}
+
+impl<T> Iterable for Vec<T> {
+    type Item = T;
+
+    type Iter<'a>
+        = std::slice::Iter<'a, T>
+    where
+        T: 'a;
+
+    fn iter(&self) -> Self::Iter<'_> {
+        (**self).iter()
+    }
+}

--- a/packages/brace-ec/src/util/mod.rs
+++ b/packages/brace-ec/src/util/mod.rs
@@ -1,0 +1,1 @@
+pub mod iter;


### PR DESCRIPTION
This adds the `Iterable` and `IterablePopulation` utility traits.

The upcoming changes need access to an iterable population to access individuals. However, this would require the use of Higher-Rank Trait Bounds (HRTBs) which would pollute the implementations with lifetimes and ugly syntax. As the purpose of this project is to allow non-Rust developers to contribute it is best to simplify this.

This change introduces a new `Iterable` trait that is implemented for the supported population types and a new `IterablePopulation` trait that has a blanket implementation for all iterable populations. This allows users to add a single bound that ensures that a type is an iterable population.