### PR TITLE
Add selection operator `Selector` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,3 +5,169 @@ version = 4
 [[package]]
 name = "brace-ec"
 version = "0.0.0"
+dependencies = [
+ "ghost",
+ "rand",
+ "thiserror",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "ghost"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39b697dbd8bfcc35d0ee91698aaa379af096368ba8837d279cc097b276edda45"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.169"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c786062daee0d6db1132800e623df74274a0a87322d8e183338e01b3d98d058"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/packages/brace-ec/Cargo.toml
+++ b/packages/brace-ec/Cargo.toml
@@ -7,3 +7,8 @@ homepage = "https://brace.rs"
 repository = "https://github.com/brace-rs/brace-ec"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+
+[dependencies]
+ghost = "0.1.18"
+rand = "0.8.5"
+thiserror = "2.0.9"

--- a/packages/brace-ec/src/core/mod.rs
+++ b/packages/brace-ec/src/core/mod.rs
@@ -1,3 +1,4 @@
 pub mod generation;
 pub mod individual;
+pub mod operator;
 pub mod population;

--- a/packages/brace-ec/src/core/operator/mod.rs
+++ b/packages/brace-ec/src/core/operator/mod.rs
@@ -1,0 +1,1 @@
+pub mod selector;

--- a/packages/brace-ec/src/core/operator/selector/first.rs
+++ b/packages/brace-ec/src/core/operator/selector/first.rs
@@ -1,0 +1,44 @@
+use rand::Rng;
+use thiserror::Error;
+
+use crate::core::population::IterablePopulation;
+
+use super::Selector;
+
+#[ghost::phantom]
+#[derive(Clone, Copy, Debug)]
+pub struct First<P: IterablePopulation>;
+
+impl<P> Selector for First<P>
+where
+    P: IterablePopulation<Individual: Clone>,
+{
+    type Population = P;
+    type Output = [P::Individual; 1];
+    type Error = FirstError;
+
+    fn select<R: Rng>(&self, population: &P, _: &mut R) -> Result<Self::Output, Self::Error> {
+        Ok([population.iter().next().ok_or(FirstError::Empty)?.clone()])
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum FirstError {
+    #[error("Empty population")]
+    Empty,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::population::Population;
+
+    use super::First;
+
+    #[test]
+    fn test_select() {
+        let population = [[0], [1], [2], [3], [4]];
+        let individual = population.select(First).unwrap()[0];
+
+        assert_eq!(population[0], individual);
+    }
+}

--- a/packages/brace-ec/src/core/operator/selector/mod.rs
+++ b/packages/brace-ec/src/core/operator/selector/mod.rs
@@ -1,0 +1,18 @@
+pub mod first;
+pub mod random;
+
+use rand::Rng;
+
+use crate::core::population::Population;
+
+pub trait Selector: Sized {
+    type Population: Population;
+    type Output: IntoIterator<Item = <Self::Population as Population>::Individual>;
+    type Error;
+
+    fn select<R: Rng>(
+        &self,
+        population: &Self::Population,
+        rng: &mut R,
+    ) -> Result<Self::Output, Self::Error>;
+}

--- a/packages/brace-ec/src/core/operator/selector/random.rs
+++ b/packages/brace-ec/src/core/operator/selector/random.rs
@@ -1,0 +1,52 @@
+use rand::seq::IteratorRandom;
+use rand::Rng;
+use thiserror::Error;
+
+use crate::core::population::IterablePopulation;
+
+use super::Selector;
+
+#[ghost::phantom]
+#[derive(Clone, Copy, Debug)]
+pub struct Random<P: IterablePopulation>;
+
+impl<P> Selector for Random<P>
+where
+    P: IterablePopulation<Individual: Clone>,
+{
+    type Population = P;
+    type Output = [P::Individual; 1];
+    type Error = RandomError;
+
+    fn select<R: Rng>(&self, population: &P, rng: &mut R) -> Result<Self::Output, Self::Error> {
+        Ok([population
+            .iter()
+            .choose(rng)
+            .ok_or(RandomError::Empty)?
+            .clone()])
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum RandomError {
+    #[error("Empty population")]
+    Empty,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::population::Population;
+
+    use super::Random;
+
+    #[test]
+    fn test_select() {
+        let population = [[0], [1], [2], [3], [4]];
+
+        for _ in 0..10 {
+            let individual = population.select(Random).unwrap()[0];
+
+            assert!(population.contains(&individual));
+        }
+    }
+}

--- a/packages/brace-ec/src/core/population.rs
+++ b/packages/brace-ec/src/core/population.rs
@@ -1,6 +1,9 @@
+use rand::thread_rng;
+
 use crate::util::iter::Iterable;
 
 use super::individual::Individual;
+use super::operator::selector::Selector;
 
 pub trait Population {
     type Individual: Individual;
@@ -9,6 +12,13 @@ pub trait Population {
 
     fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    fn select<S>(&self, selector: S) -> Result<S::Output, S::Error>
+    where
+        S: Selector<Population = Self>,
+    {
+        selector.select(self, &mut thread_rng())
     }
 }
 


### PR DESCRIPTION
This adds the `Selector` trait with basic `First` and `Random` implementations.

Evolutionary algorithms make use of genetic operators including selection, mutation and recombination. Selection is important as it allows the algorithm to pick individuals from an existing population in order to evolve the next generation.

This change introduces the `Selector` trait to select individuals from a population. The implementation has gone through several iterations since the project inception and has settled on using an associated population instead of a generic. This is vital for selector composition that leverages the type system to provide immediate feedback. A prior iteration used a generic instead and this meant that composing selectors became problematic when trait bounds were not met.

This includes two initial selectors. The `First` selector is used to get the first individual from a population. This name may not be entirely accurate in the future if a population uses unstable iteration. The second is `Random` which chooses an individual at random. These selectors make use of the `ghost` crate to specify the population without resorting to using `PhantomData`.

The population on the included selector types is a side-effect of the associated population design. In real-world usage this should not be a problem as the type should be inferred but there may be situations where the type must be manually specified.

The change also includes a `select` method on `Population` to simplify selection without needing to provide a random number generator.