### PR TITLE
Add mutation operator `Mutator` trait

### DIFF
--- a/packages/brace-ec/src/core/individual.rs
+++ b/packages/brace-ec/src/core/individual.rs
@@ -1,7 +1,19 @@
+use rand::thread_rng;
+
+use super::operator::mutator::Mutator;
+
 pub trait Individual {
     type Genome: ?Sized;
 
     fn genome(&self) -> &Self::Genome;
+
+    fn mutate<M>(self, mutator: M) -> Result<Self, M::Error>
+    where
+        M: Mutator<Individual = Self>,
+        Self: Sized,
+    {
+        mutator.mutate(self, &mut thread_rng())
+    }
 }
 
 impl<T, const N: usize> Individual for [T; N] {

--- a/packages/brace-ec/src/core/operator/mod.rs
+++ b/packages/brace-ec/src/core/operator/mod.rs
@@ -1,1 +1,2 @@
+pub mod mutator;
 pub mod selector;

--- a/packages/brace-ec/src/core/operator/mutator/mod.rs
+++ b/packages/brace-ec/src/core/operator/mutator/mod.rs
@@ -1,0 +1,47 @@
+use rand::Rng;
+
+use crate::core::individual::Individual;
+
+pub trait Mutator: Sized {
+    type Individual: Individual;
+    type Error;
+
+    fn mutate<R: Rng>(
+        &self,
+        individual: Self::Individual,
+        rng: &mut R,
+    ) -> Result<Self::Individual, Self::Error>;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+
+    use rand::Rng;
+
+    use crate::core::individual::Individual;
+
+    use super::Mutator;
+
+    struct Swap;
+
+    impl Mutator for Swap {
+        type Individual = [u32; 2];
+        type Error = Infallible;
+
+        fn mutate<R: Rng>(
+            &self,
+            individual: Self::Individual,
+            _: &mut R,
+        ) -> Result<Self::Individual, Self::Error> {
+            Ok([individual[1], individual[0]])
+        }
+    }
+
+    #[test]
+    fn test_mutator() {
+        let individual = [0, 1].mutate(Swap).unwrap();
+
+        assert_eq!(individual, [1, 0]);
+    }
+}


### PR DESCRIPTION
This adds the `Mutator` trait with a simple test implementation.

Mutation is an important step of evolutionary algorithms and this encapsulates that concept as a trait.

This change introduces the `Mutator` trait and adds a `mutate` method to the `Individual` trait. This does not include any usable mutators and only includes a trivial example in the tests. The `Swap` mutator could be publicly exposed but it isn't particularly useful in its current state. Perhaps a more generic `Shuffle` mutator would make more sense but it isn't obvious as to how that would be implemented.