### PR TITLE
Add recombination operator `Recombinator` trait

### DIFF
--- a/packages/brace-ec/src/core/operator/mod.rs
+++ b/packages/brace-ec/src/core/operator/mod.rs
@@ -1,2 +1,3 @@
 pub mod mutator;
+pub mod recombinator;
 pub mod selector;

--- a/packages/brace-ec/src/core/operator/recombinator/mod.rs
+++ b/packages/brace-ec/src/core/operator/recombinator/mod.rs
@@ -1,0 +1,50 @@
+use rand::Rng;
+
+use crate::core::population::Population;
+
+pub trait Recombinator {
+    type Parents: Population;
+    type Output: IntoIterator<Item = <Self::Parents as Population>::Individual>;
+    type Error;
+
+    fn recombine<R: Rng>(
+        &self,
+        parents: Self::Parents,
+        rng: &mut R,
+    ) -> Result<Self::Output, Self::Error>;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+
+    use rand::Rng;
+
+    use crate::core::population::Population;
+
+    use super::Recombinator;
+
+    struct Swap;
+
+    impl Recombinator for Swap {
+        type Parents = [[i32; 2]; 2];
+        type Output = [[i32; 2]; 2];
+        type Error = Infallible;
+
+        fn recombine<R: Rng>(
+            &self,
+            parents: Self::Parents,
+            _: &mut R,
+        ) -> Result<Self::Output, Self::Error> {
+            Ok([parents[1], parents[0]])
+        }
+    }
+
+    #[test]
+    fn test_recombinator() {
+        let individuals = [[0, 0], [1, 1]].recombine(Swap).unwrap();
+
+        assert_eq!(individuals[0], [1, 1]);
+        assert_eq!(individuals[1], [0, 0]);
+    }
+}

--- a/packages/brace-ec/src/core/population.rs
+++ b/packages/brace-ec/src/core/population.rs
@@ -3,6 +3,7 @@ use rand::thread_rng;
 use crate::util::iter::Iterable;
 
 use super::individual::Individual;
+use super::operator::recombinator::Recombinator;
 use super::operator::selector::Selector;
 
 pub trait Population {
@@ -19,6 +20,14 @@ pub trait Population {
         S: Selector<Population = Self>,
     {
         selector.select(self, &mut thread_rng())
+    }
+
+    fn recombine<R>(self, recombinator: R) -> Result<R::Output, R::Error>
+    where
+        R: Recombinator<Parents = Self>,
+        Self: Sized,
+    {
+        recombinator.recombine(self, &mut thread_rng())
     }
 }
 


### PR DESCRIPTION
This adds the `Recombinator` trait with a simple test implementation.

Recombination is an important step of evolutionary algorithms and this encapsulates that concept as a trait.

This change introduces the `Recombinator` trait and adds a `recombine` method to the `Population` trait. This does not include any usable recombinators and only includes a trivial example in the tests. The `Swap` recombinator could be publicly exposed but it isn't particularly useful in evolutionary computation.