### PR TITLE
Add `Individual::genome_mut` method

### DIFF
--- a/packages/brace-ec/src/core/individual.rs
+++ b/packages/brace-ec/src/core/individual.rs
@@ -7,6 +7,8 @@ pub trait Individual {
 
     fn genome(&self) -> &Self::Genome;
 
+    fn genome_mut(&mut self) -> &mut Self::Genome;
+
     fn mutate<M>(self, mutator: M) -> Result<Self, M::Error>
     where
         M: Mutator<Individual = Self>,
@@ -22,12 +24,20 @@ impl<T, const N: usize> Individual for [T; N] {
     fn genome(&self) -> &Self::Genome {
         self
     }
+
+    fn genome_mut(&mut self) -> &mut Self::Genome {
+        self
+    }
 }
 
 impl<T> Individual for Vec<T> {
     type Genome = [T];
 
     fn genome(&self) -> &Self::Genome {
+        self
+    }
+
+    fn genome_mut(&mut self) -> &mut Self::Genome {
         self
     }
 }


### PR DESCRIPTION
This adds the `genome_mut` method to the `Individual` trait.

The `Individual` is a distinct concept to the `Genome` that contains a genome but may also store other information such as the score/fitness. The idea is that the individual can be wrapped in layers of abstraction that add new functionality but operators such as mutation are likely to want access to the inner genome.

This change simply adds the `Individual::genome_mut` method to complement the `Individual::genome` method and get mutable access to the genome of an individual.