### PR TITLE
Add `Mutate` selector adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,9 +3,25 @@
 version = 4
 
 [[package]]
+name = "array-util"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e509844de8f09b90a2c3444684a2b6695f4071360e13d2fda0af9f749cc2ed6"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "brace-ec"
 version = "0.0.0"
 dependencies = [
+ "array-util",
  "ghost",
  "rand",
  "thiserror",

--- a/packages/brace-ec/Cargo.toml
+++ b/packages/brace-ec/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [dependencies]
+array-util = "1.0.2"
 ghost = "0.1.18"
 rand = "0.8.5"
 thiserror = "2.0.9"

--- a/packages/brace-ec/src/core/operator/selector/mod.rs
+++ b/packages/brace-ec/src/core/operator/selector/mod.rs
@@ -1,9 +1,14 @@
 pub mod first;
+pub mod mutate;
 pub mod random;
 
 use rand::Rng;
 
 use crate::core::population::Population;
+
+use self::mutate::Mutate;
+
+use super::mutator::Mutator;
 
 pub trait Selector: Sized {
     type Population: Population;
@@ -15,4 +20,11 @@ pub trait Selector: Sized {
         population: &Self::Population,
         rng: &mut R,
     ) -> Result<Self::Output, Self::Error>;
+
+    fn mutate<M>(self, mutator: M) -> Mutate<Self, M>
+    where
+        M: Mutator<Individual = <Self::Population as Population>::Individual>,
+    {
+        Mutate::new(self, mutator)
+    }
 }

--- a/packages/brace-ec/src/core/operator/selector/mutate.rs
+++ b/packages/brace-ec/src/core/operator/selector/mutate.rs
@@ -1,0 +1,93 @@
+use rand::Rng;
+use thiserror::Error;
+
+use crate::core::operator::mutator::Mutator;
+use crate::core::population::Population;
+use crate::util::map::TryMap;
+
+use super::Selector;
+
+pub struct Mutate<S, M> {
+    selector: S,
+    mutator: M,
+}
+
+impl<S, M> Mutate<S, M> {
+    pub fn new(selector: S, mutator: M) -> Self {
+        Self { selector, mutator }
+    }
+}
+
+impl<S, M> Selector for Mutate<S, M>
+where
+    S: Selector<Output: TryMap<Item = <S::Population as Population>::Individual>>,
+    M: Mutator<Individual = <S::Population as Population>::Individual>,
+{
+    type Population = S::Population;
+    type Output = S::Output;
+    type Error = MutateError<S::Error, M::Error>;
+
+    fn select<R: Rng>(
+        &self,
+        population: &Self::Population,
+        rng: &mut R,
+    ) -> Result<Self::Output, Self::Error> {
+        self.selector
+            .select(population, rng)
+            .map_err(MutateError::Select)?
+            .try_map(|individual| self.mutator.mutate(individual, rng))
+            .map_err(MutateError::Mutate)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum MutateError<S, M> {
+    #[error(transparent)]
+    Select(S),
+    #[error(transparent)]
+    Mutate(M),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+
+    use rand::Rng;
+
+    use crate::core::operator::mutator::Mutator;
+    use crate::core::operator::selector::first::First;
+    use crate::core::operator::selector::Selector;
+    use crate::core::population::Population;
+
+    struct Increment;
+
+    impl Mutator for Increment {
+        type Individual = [u32; 2];
+        type Error = Infallible;
+
+        fn mutate<R: Rng>(
+            &self,
+            mut individual: Self::Individual,
+            _: &mut R,
+        ) -> Result<Self::Individual, Self::Error> {
+            individual[0] += 1;
+            individual[1] += 1;
+
+            Ok(individual)
+        }
+    }
+
+    #[test]
+    fn test_mutate_selector() {
+        let population = [[0, 0]];
+        let individual = population.select(First.mutate(Increment)).unwrap()[0];
+
+        assert_eq!(individual, [1, 1]);
+
+        let individual = population
+            .select(First.mutate(Increment).mutate(Increment))
+            .unwrap()[0];
+
+        assert_eq!(individual, [2, 2]);
+    }
+}

--- a/packages/brace-ec/src/util/map.rs
+++ b/packages/brace-ec/src/util/map.rs
@@ -1,0 +1,30 @@
+pub trait TryMap {
+    type Item;
+
+    fn try_map<F, E>(self, f: F) -> Result<Self, E>
+    where
+        F: FnMut(Self::Item) -> Result<Self::Item, E>,
+        Self: Sized;
+}
+
+impl<const N: usize, T> TryMap for [T; N] {
+    type Item = T;
+
+    fn try_map<F, E>(self, f: F) -> Result<Self, E>
+    where
+        F: FnMut(Self::Item) -> Result<Self::Item, E>,
+    {
+        array_util::try_map(self, f)
+    }
+}
+
+impl<T> TryMap for Vec<T> {
+    type Item = T;
+
+    fn try_map<F, E>(self, f: F) -> Result<Self, E>
+    where
+        F: FnMut(Self::Item) -> Result<Self::Item, E>,
+    {
+        self.into_iter().map(f).collect()
+    }
+}

--- a/packages/brace-ec/src/util/mod.rs
+++ b/packages/brace-ec/src/util/mod.rs
@@ -1,1 +1,2 @@
 pub mod iter;
+pub mod map;


### PR DESCRIPTION
This adds the `Mutate` selector adapter which adapts another selector by applying a mutator.

Mutation in evolutionary computation is a distinct operator to selection, but for the purposes of this project the act of selection is the entire operator flow which includes mutation and recombination. Rather than selecting an existing individual from a population it can be seen as selecting a new individual for the next population.

This change adds a new `Mutate` type which composes a selector and a mutator to form a new selector. This includes a new `TryMap` utility trait and the `array-util` crate to map fixed-length arrays. The `Selector::mutate` method simplifies the construction of the new selector and allows repeated chaining.