### PR TITLE
Implement `Individual` for scalar primitives

### DIFF
--- a/packages/brace-ec/src/core/individual.rs
+++ b/packages/brace-ec/src/core/individual.rs
@@ -42,6 +42,26 @@ impl<T> Individual for Vec<T> {
     }
 }
 
+macro_rules! impl_individual {
+    ($($type:path),+) => {
+        $(impl Individual for $type {
+            type Genome = Self;
+
+            fn genome(&self) -> &Self::Genome {
+                self
+            }
+
+            fn genome_mut(&mut self) -> &mut Self::Genome {
+                self
+            }
+        })+
+    };
+}
+
+impl_individual!(u8, u16, u32, u64, u128, usize);
+impl_individual!(i8, i16, i32, i64, i128, isize);
+impl_individual!(f32, f64, char, bool);
+
 #[cfg(test)]
 mod tests {
     use super::Individual;

--- a/packages/brace-ec/src/core/operator/recombinator/mod.rs
+++ b/packages/brace-ec/src/core/operator/recombinator/mod.rs
@@ -27,8 +27,8 @@ mod tests {
     struct Swap;
 
     impl Recombinator for Swap {
-        type Parents = [[i32; 2]; 2];
-        type Output = [[i32; 2]; 2];
+        type Parents = [u8; 2];
+        type Output = [u8; 2];
         type Error = Infallible;
 
         fn recombine<R: Rng>(
@@ -42,9 +42,9 @@ mod tests {
 
     #[test]
     fn test_recombinator() {
-        let individuals = [[0, 0], [1, 1]].recombine(Swap).unwrap();
+        let individuals = [0, 1].recombine(Swap).unwrap();
 
-        assert_eq!(individuals[0], [1, 1]);
-        assert_eq!(individuals[1], [0, 0]);
+        assert_eq!(individuals[0], 1);
+        assert_eq!(individuals[1], 0);
     }
 }

--- a/packages/brace-ec/src/core/operator/selector/first.rs
+++ b/packages/brace-ec/src/core/operator/selector/first.rs
@@ -36,7 +36,7 @@ mod tests {
 
     #[test]
     fn test_select() {
-        let population = [[0], [1], [2], [3], [4]];
+        let population = [0, 1, 2, 3, 4];
         let individual = population.select(First).unwrap()[0];
 
         assert_eq!(population[0], individual);

--- a/packages/brace-ec/src/core/operator/selector/mutate.rs
+++ b/packages/brace-ec/src/core/operator/selector/mutate.rs
@@ -51,6 +51,7 @@ pub enum MutateError<S, M> {
 #[cfg(test)]
 mod tests {
     use std::convert::Infallible;
+    use std::ops::Add;
 
     use rand::Rng;
 
@@ -62,32 +63,29 @@ mod tests {
     struct Increment;
 
     impl Mutator for Increment {
-        type Individual = [u32; 2];
+        type Individual = u8;
         type Error = Infallible;
 
         fn mutate<R: Rng>(
             &self,
-            mut individual: Self::Individual,
+            individual: Self::Individual,
             _: &mut R,
         ) -> Result<Self::Individual, Self::Error> {
-            individual[0] += 1;
-            individual[1] += 1;
-
-            Ok(individual)
+            Ok(individual.add(1))
         }
     }
 
     #[test]
     fn test_mutate_selector() {
-        let population = [[0, 0]];
+        let population = [0];
         let individual = population.select(First.mutate(Increment)).unwrap()[0];
 
-        assert_eq!(individual, [1, 1]);
+        assert_eq!(individual, 1);
 
         let individual = population
             .select(First.mutate(Increment).mutate(Increment))
             .unwrap()[0];
 
-        assert_eq!(individual, [2, 2]);
+        assert_eq!(individual, 2);
     }
 }

--- a/packages/brace-ec/src/core/operator/selector/random.rs
+++ b/packages/brace-ec/src/core/operator/selector/random.rs
@@ -41,7 +41,7 @@ mod tests {
 
     #[test]
     fn test_select() {
-        let population = [[0], [1], [2], [3], [4]];
+        let population = [0, 1, 2, 3, 4];
 
         for _ in 0..10 {
             let individual = population.select(Random).unwrap()[0];


### PR DESCRIPTION
This implements the `Individual` trait for the Rust scalar primitives.

The `Individual` trait is currently only implemented on arrays and vectors and this is not ideal. Various operators that are yet to be implemented act on scalar types and so these types need to implement the trait. This also complicates tests by adding extra boilerplate to construct a valid individual.

This change implements the `Individual` trait for scalar primitives via a simple macro to reduce the boilerplate code. It also updates various tests to simplify them using the newly supported individuals. This should help ensure that the macro is working correctly without adding new tests or introducing a crate such as `static_assertions`.