### PR TITLE
Add evolution operator `Evolver` trait

### DIFF
--- a/packages/brace-ec/src/core/operator/evolver/mod.rs
+++ b/packages/brace-ec/src/core/operator/evolver/mod.rs
@@ -1,0 +1,40 @@
+use crate::core::generation::Generation;
+
+pub trait Evolver {
+    type Generation: Generation;
+    type Error;
+
+    fn evolve(&self, generation: Self::Generation) -> Result<Self::Generation, Self::Error>;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+
+    use super::Evolver;
+
+    struct Increment;
+
+    impl Evolver for Increment {
+        type Generation = (u8, [u8; 2]);
+        type Error = Infallible;
+
+        fn evolve(
+            &self,
+            mut generation: Self::Generation,
+        ) -> Result<Self::Generation, Self::Error> {
+            generation.0 += 1;
+            generation.1[0] += 1;
+            generation.1[1] += 1;
+
+            Ok(generation)
+        }
+    }
+
+    #[test]
+    fn test_evolver() {
+        let generation = Increment.evolve((0, [0, 1])).unwrap();
+
+        assert_eq!(generation, (1, [1, 2]));
+    }
+}

--- a/packages/brace-ec/src/core/operator/mod.rs
+++ b/packages/brace-ec/src/core/operator/mod.rs
@@ -1,3 +1,4 @@
+pub mod evolver;
 pub mod mutator;
 pub mod recombinator;
 pub mod selector;


### PR DESCRIPTION
This adds a new `Evolver` trait for evolving generations.

In evolutionary computation the typical genetic operators are *selection*, *mutation*, and *recombination*. These describe the process of returning individuals but there is a need to describe the larger process of evolving one generation to the next.

This change introduces the `Evolver` trait that describes the ability to evolve a generation. This can be seen as an operator for an entire population much like a mutator is an operator for a single individual.

There are a few key details in the design of this trait. Firstly, it takes ownership of a generation and returns a generation instead of storing or mutating a generation in place. Secondly, it currently takes `&self` and would require interior mutability to update itself. This is not a hard requirement and it may later be changed to take `&mut self` if required for a more complex evolver. Thirdly, it does not take a random number generator like the other operators as it is up to the evolver to provide this if needed. Lastly, there is no requirement of providing a selector to the evolver as not all evolvers may need a selector.