### PR TITLE
Add `Select` evolver

### DIFF
--- a/packages/brace-ec/src/core/operator/evolver/mod.rs
+++ b/packages/brace-ec/src/core/operator/evolver/mod.rs
@@ -1,3 +1,5 @@
+pub mod select;
+
 use crate::core::generation::Generation;
 
 pub trait Evolver {

--- a/packages/brace-ec/src/core/operator/evolver/select.rs
+++ b/packages/brace-ec/src/core/operator/evolver/select.rs
@@ -1,0 +1,93 @@
+use rand::thread_rng;
+use thiserror::Error;
+
+use crate::core::generation::Generation;
+use crate::core::operator::selector::Selector;
+use crate::core::population::Population;
+use crate::util::map::TryMap;
+
+use super::Evolver;
+
+#[derive(Clone, Debug, Default)]
+pub struct Select<S> {
+    selector: S,
+}
+
+impl<S> Select<S> {
+    pub fn new(selector: S) -> Self {
+        Self { selector }
+    }
+}
+
+impl<S, P> Evolver for Select<S>
+where
+    S: Selector<Population = P>,
+    P: Population + Clone + TryMap<Item = P::Individual>,
+{
+    type Generation = (u64, S::Population);
+    type Error = SelectError<S::Error>;
+
+    fn evolve(&self, mut generation: Self::Generation) -> Result<Self::Generation, Self::Error> {
+        let mut rng = thread_rng();
+        let mut selection = self
+            .selector
+            .select(generation.population(), &mut rng)
+            .map_err(SelectError::Select)?
+            .into_iter();
+
+        let population = generation
+            .population()
+            .clone()
+            .try_map(|_| match selection.next() {
+                Some(individual) => Ok(individual),
+                None => {
+                    selection = self
+                        .selector
+                        .select(generation.population(), &mut rng)
+                        .map_err(SelectError::Select)?
+                        .into_iter();
+
+                    match selection.next() {
+                        Some(individual) => Ok(individual),
+                        None => Err(SelectError::NotEnough),
+                    }
+                }
+            })?;
+
+        generation.0 += 1;
+        generation.1 = population;
+
+        Ok(generation)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum SelectError<S> {
+    #[error("unable to fill population from selector")]
+    NotEnough,
+    #[error(transparent)]
+    Select(S),
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::operator::evolver::Evolver;
+    use crate::core::operator::selector::random::Random;
+
+    use super::Select;
+
+    #[test]
+    fn test_select_evolver() {
+        let evolver = Select::new(Random);
+        let population = [0, 1, 2, 3, 4];
+        let generation = evolver.evolve((0, population)).unwrap();
+
+        assert_eq!(generation.0, 1);
+        assert!(generation.1.iter().all(|i| population.contains(i)));
+
+        let generation = evolver.evolve(generation).unwrap();
+
+        assert_eq!(generation.0, 2);
+        assert!(generation.1.iter().all(|i| population.contains(i)));
+    }
+}


### PR DESCRIPTION
This adds a new `Select` evolver that uses a selector to generate a new population.

Evolutionary computation typically uses a combination of genetic operators to evolve the next generation of individuals from the current generation. However, the `Evolver` trait introduced in #9 does not require selectors to be used at all. This is just an implementation detail for a specific type of evolver.

This change adds a new `Select` evolver that stores an internal selector in order to generate an entirely new population by repeatedly calling the selector. The implementation may not be ideal but it is a good starting point for creating example algorithms. It currently uses a fixed type of generation but this could be changed by updating the `Generation` trait with additional functionality to manipulate the identifier and population.

The implementation also requires that the population implement both `Clone` and `TryMap` as it was the simplest option without introducing new traits. It currently clones the population and maps the individuals to ensure that the population size is correct without using the previous individual. As the selector can return multiple individuals it is implemented in such a way that the selector is only called as many times as necessary. A parallel version might require the selector to return a single individual.

Another possible implementation might be to use a `TryFromIterator` trait but there are questions about how to ensure the correct population size for types such as `Vec` with a dynamic length. That would also require the selector to return a single individual.

Unfortunately the implementation creates a new population for each generation and this may require a large allocation. This could be fixed by making the evolver take `&mut self` and storing the first clone to reuse and swap as necessary so that there should only ever be two allocations. Perhaps a `Cell<Option<Population>>` might also work. The use of `TryMap` relies on the specialisation of `FromIterator` for `Vec` to reuse the same allocation on collect but there must surely be a better option that is just as flexible.