### PR TITLE
Set operator output bound to `Population`

### DIFF
--- a/packages/brace-ec/src/core/operator/evolver/select.rs
+++ b/packages/brace-ec/src/core/operator/evolver/select.rs
@@ -21,7 +21,7 @@ impl<S> Select<S> {
 
 impl<S, P> Evolver for Select<S>
 where
-    S: Selector<Population = P>,
+    S: Selector<Population = P, Output: IntoIterator<Item = P::Individual>>,
     P: Population + Clone + TryMap<Item = P::Individual>,
 {
     type Generation = (u64, S::Population);

--- a/packages/brace-ec/src/core/operator/recombinator/mod.rs
+++ b/packages/brace-ec/src/core/operator/recombinator/mod.rs
@@ -4,7 +4,7 @@ use crate::core::population::Population;
 
 pub trait Recombinator {
     type Parents: Population;
-    type Output: IntoIterator<Item = <Self::Parents as Population>::Individual>;
+    type Output: Population<Individual = <Self::Parents as Population>::Individual>;
     type Error;
 
     fn recombine<R: Rng>(

--- a/packages/brace-ec/src/core/operator/selector/mod.rs
+++ b/packages/brace-ec/src/core/operator/selector/mod.rs
@@ -12,7 +12,7 @@ use super::mutator::Mutator;
 
 pub trait Selector: Sized {
     type Population: Population;
-    type Output: IntoIterator<Item = <Self::Population as Population>::Individual>;
+    type Output: Population<Individual = <Self::Population as Population>::Individual>;
     type Error;
 
     fn select<R: Rng>(


### PR DESCRIPTION
This updates the `Selector` and `Recombinator` operator associated outputs to use `Population` instead of `IntoIterator`.

The `Population` trait in this project is a defined as a collection of individuals. Both the `Selector` and `Recombinator` traits currently return an iterator of individuals from the input population. However, not all operators require the `IntoIterator` bound to exist. Instead, it makes more sense to use the `Population` bound to clarify the intent and add the `IntoIterator` bound where appropriate.

This change simply replaces the `IntoIterator` bound for the `Selector` and `Recombinator` associated outputs with a bound on `Population` instead. This need not be the same population as the output is more likely to be a vector or array but it does ensure that the operator flow uses consistent types that might easily be composed in the future.

This also updates the `Select` evolver to include an `IntoIterator` bound as required. A parallel version of this that only supports a selector that returns an array of a single individual would not have needed the `IntoIterator` bound.