### PR TITLE
Implement `Population` for `Option`

### DIFF
--- a/packages/brace-ec/src/core/population.rs
+++ b/packages/brace-ec/src/core/population.rs
@@ -53,6 +53,20 @@ where
     }
 }
 
+impl<T> Population for Option<T>
+where
+    T: Individual,
+{
+    type Individual = T;
+
+    fn len(&self) -> usize {
+        match self {
+            Some(_) => 1,
+            None => 0,
+        }
+    }
+}
+
 pub trait IterablePopulation: Population + Iterable<Item = Self::Individual> {}
 
 impl<T> IterablePopulation for T where T: Population + Iterable<Item = Self::Individual> {}

--- a/packages/brace-ec/src/util/iter.rs
+++ b/packages/brace-ec/src/util/iter.rs
@@ -33,3 +33,16 @@ impl<T> Iterable for Vec<T> {
         (**self).iter()
     }
 }
+
+impl<T> Iterable for Option<T> {
+    type Item = T;
+
+    type Iter<'a>
+        = std::option::Iter<'a, T>
+    where
+        Self: 'a;
+
+    fn iter(&self) -> Self::Iter<'_> {
+        self.iter()
+    }
+}

--- a/packages/brace-ec/src/util/map.rs
+++ b/packages/brace-ec/src/util/map.rs
@@ -28,3 +28,17 @@ impl<T> TryMap for Vec<T> {
         self.into_iter().map(f).collect()
     }
 }
+
+impl<T> TryMap for Option<T> {
+    type Item = T;
+
+    fn try_map<F, E>(self, mut f: F) -> Result<Self, E>
+    where
+        F: FnMut(Self::Item) -> Result<Self::Item, E>,
+    {
+        match self {
+            Some(item) => f(item).map(Some),
+            None => Ok(None),
+        }
+    }
+}


### PR DESCRIPTION
This implements `Population` and the various utility traits for `Option`.

With the previous change #11 updating the operator output to be a `Population` there is a need to expand the trait to cover other types that were supported before. In particular it was previously possible for a selector to return an `Option` as the output but that is no longer possible.

This change simply implements `Population`, `Iterable` and `TryMap` for `Option`. This should work similarly to a `Vec` population that might be empty or might have a single individual. There is no simple way to avoid runtime length checks without const generics which would have its own set of limitations.