### PR TITLE
Add `?Sized` bound to operator `R: Rng`

### DIFF
--- a/packages/brace-ec/src/core/operator/mutator/mod.rs
+++ b/packages/brace-ec/src/core/operator/mutator/mod.rs
@@ -6,11 +6,13 @@ pub trait Mutator: Sized {
     type Individual: Individual;
     type Error;
 
-    fn mutate<R: Rng>(
+    fn mutate<R>(
         &self,
         individual: Self::Individual,
         rng: &mut R,
-    ) -> Result<Self::Individual, Self::Error>;
+    ) -> Result<Self::Individual, Self::Error>
+    where
+        R: Rng + ?Sized;
 }
 
 #[cfg(test)]
@@ -29,11 +31,14 @@ mod tests {
         type Individual = [u32; 2];
         type Error = Infallible;
 
-        fn mutate<R: Rng>(
+        fn mutate<R>(
             &self,
             individual: Self::Individual,
             _: &mut R,
-        ) -> Result<Self::Individual, Self::Error> {
+        ) -> Result<Self::Individual, Self::Error>
+        where
+            R: Rng + ?Sized,
+        {
             Ok([individual[1], individual[0]])
         }
     }

--- a/packages/brace-ec/src/core/operator/recombinator/mod.rs
+++ b/packages/brace-ec/src/core/operator/recombinator/mod.rs
@@ -7,11 +7,13 @@ pub trait Recombinator {
     type Output: Population<Individual = <Self::Parents as Population>::Individual>;
     type Error;
 
-    fn recombine<R: Rng>(
+    fn recombine<R>(
         &self,
         parents: Self::Parents,
         rng: &mut R,
-    ) -> Result<Self::Output, Self::Error>;
+    ) -> Result<Self::Output, Self::Error>
+    where
+        R: Rng + ?Sized;
 }
 
 #[cfg(test)]
@@ -31,11 +33,14 @@ mod tests {
         type Output = [u8; 2];
         type Error = Infallible;
 
-        fn recombine<R: Rng>(
+        fn recombine<R>(
             &self,
             parents: Self::Parents,
             _: &mut R,
-        ) -> Result<Self::Output, Self::Error> {
+        ) -> Result<Self::Output, Self::Error>
+        where
+            R: Rng + ?Sized,
+        {
             Ok([parents[1], parents[0]])
         }
     }

--- a/packages/brace-ec/src/core/operator/selector/first.rs
+++ b/packages/brace-ec/src/core/operator/selector/first.rs
@@ -17,7 +17,10 @@ where
     type Output = [P::Individual; 1];
     type Error = FirstError;
 
-    fn select<R: Rng>(&self, population: &P, _: &mut R) -> Result<Self::Output, Self::Error> {
+    fn select<R>(&self, population: &P, _: &mut R) -> Result<Self::Output, Self::Error>
+    where
+        R: Rng + ?Sized,
+    {
         Ok([population.iter().next().ok_or(FirstError::Empty)?.clone()])
     }
 }

--- a/packages/brace-ec/src/core/operator/selector/mod.rs
+++ b/packages/brace-ec/src/core/operator/selector/mod.rs
@@ -15,11 +15,13 @@ pub trait Selector: Sized {
     type Output: Population<Individual = <Self::Population as Population>::Individual>;
     type Error;
 
-    fn select<R: Rng>(
+    fn select<R>(
         &self,
         population: &Self::Population,
         rng: &mut R,
-    ) -> Result<Self::Output, Self::Error>;
+    ) -> Result<Self::Output, Self::Error>
+    where
+        R: Rng + ?Sized;
 
     fn mutate<M>(self, mutator: M) -> Mutate<Self, M>
     where

--- a/packages/brace-ec/src/core/operator/selector/mutate.rs
+++ b/packages/brace-ec/src/core/operator/selector/mutate.rs
@@ -27,11 +27,14 @@ where
     type Output = S::Output;
     type Error = MutateError<S::Error, M::Error>;
 
-    fn select<R: Rng>(
+    fn select<R>(
         &self,
         population: &Self::Population,
         rng: &mut R,
-    ) -> Result<Self::Output, Self::Error> {
+    ) -> Result<Self::Output, Self::Error>
+    where
+        R: Rng + ?Sized,
+    {
         self.selector
             .select(population, rng)
             .map_err(MutateError::Select)?
@@ -66,11 +69,14 @@ mod tests {
         type Individual = u8;
         type Error = Infallible;
 
-        fn mutate<R: Rng>(
+        fn mutate<R>(
             &self,
             individual: Self::Individual,
             _: &mut R,
-        ) -> Result<Self::Individual, Self::Error> {
+        ) -> Result<Self::Individual, Self::Error>
+        where
+            R: Rng + ?Sized,
+        {
             Ok(individual.add(1))
         }
     }

--- a/packages/brace-ec/src/core/operator/selector/random.rs
+++ b/packages/brace-ec/src/core/operator/selector/random.rs
@@ -18,7 +18,10 @@ where
     type Output = [P::Individual; 1];
     type Error = RandomError;
 
-    fn select<R: Rng>(&self, population: &P, rng: &mut R) -> Result<Self::Output, Self::Error> {
+    fn select<R>(&self, population: &P, rng: &mut R) -> Result<Self::Output, Self::Error>
+    where
+        R: Rng + ?Sized,
+    {
         Ok([population
             .iter()
             .choose(rng)


### PR DESCRIPTION
This updates the generic `R` on operator methods to support unsized random number generators.

The documentation for `rand::Rng` describes two ways of providing random number generators. The first is to pass an `&mut R` where `R: Rng + ?Sized` and the second is to pass `R` where `R: Rng`. The latter would be simpler but would typically require the random number generator to be borrowed from another borrow. The compiler may be able to eliminate the second borrow but if not then there would be a minor overhead. In complex nested operators this may lead to multiple levels of borrowing. Instead, the project opted for the first option but did not relax the `Sized` bound.

This change simply updates every instance of the `select`, `mutate` and `recombine` methods to add the `?Sized` bound as the documentation recommends. The existing `Rng` bound has also been moved to the where clause to make it easier to read and less likely for the method to span multiple lines.