### PR TITLE
Add `Recombine` selector

### DIFF
--- a/packages/brace-ec/src/core/operator/selector/mod.rs
+++ b/packages/brace-ec/src/core/operator/selector/mod.rs
@@ -1,14 +1,17 @@
 pub mod first;
 pub mod mutate;
 pub mod random;
+pub mod recombine;
 
 use rand::Rng;
 
 use crate::core::population::Population;
 
 use self::mutate::Mutate;
+use self::recombine::Recombine;
 
 use super::mutator::Mutator;
+use super::recombinator::Recombinator;
 
 pub trait Selector: Sized {
     type Population: Population;
@@ -28,5 +31,12 @@ pub trait Selector: Sized {
         M: Mutator<Individual = <Self::Population as Population>::Individual>,
     {
         Mutate::new(self, mutator)
+    }
+
+    fn recombine<R>(self, recombinator: R) -> Recombine<Self, R>
+    where
+        R: Recombinator<Parents = Self::Output>,
+    {
+        Recombine::new(self, recombinator)
     }
 }

--- a/packages/brace-ec/src/core/operator/selector/recombine.rs
+++ b/packages/brace-ec/src/core/operator/selector/recombine.rs
@@ -1,0 +1,113 @@
+use rand::Rng;
+use thiserror::Error;
+
+use crate::core::operator::recombinator::Recombinator;
+
+use super::Selector;
+
+pub struct Recombine<S, R> {
+    selector: S,
+    recombinator: R,
+}
+
+impl<S, R> Recombine<S, R> {
+    pub fn new(selector: S, recombinator: R) -> Self {
+        Self {
+            selector,
+            recombinator,
+        }
+    }
+}
+
+impl<S, R> Selector for Recombine<S, R>
+where
+    S: Selector,
+    R: Recombinator<Parents = S::Output>,
+{
+    type Population = S::Population;
+    type Output = R::Output;
+    type Error = RecombineError<S::Error, R::Error>;
+
+    fn select<G>(
+        &self,
+        population: &Self::Population,
+        rng: &mut G,
+    ) -> Result<Self::Output, Self::Error>
+    where
+        G: Rng + ?Sized,
+    {
+        let parents = self
+            .selector
+            .select(population, rng)
+            .map_err(RecombineError::Select)?;
+
+        self.recombinator
+            .recombine(parents, rng)
+            .map_err(RecombineError::Recombine)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum RecombineError<S, R> {
+    #[error(transparent)]
+    Select(S),
+    #[error(transparent)]
+    Recombine(R),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+
+    use rand::Rng;
+
+    use crate::core::operator::recombinator::Recombinator;
+    use crate::core::operator::selector::Selector;
+    use crate::core::population::Population;
+
+    struct LastTwo;
+
+    impl Selector for LastTwo {
+        type Population = [u8; 5];
+        type Output = [u8; 2];
+        type Error = Infallible;
+
+        fn select<R>(
+            &self,
+            population: &Self::Population,
+            _: &mut R,
+        ) -> Result<Self::Output, Self::Error>
+        where
+            R: Rng + ?Sized,
+        {
+            Ok([population[3], population[4]])
+        }
+    }
+
+    struct Add;
+
+    impl Recombinator for Add {
+        type Parents = [u8; 2];
+        type Output = [u8; 1];
+        type Error = Infallible;
+
+        fn recombine<R>(
+            &self,
+            [a, b]: Self::Parents,
+            _: &mut R,
+        ) -> Result<Self::Output, Self::Error>
+        where
+            R: Rng + ?Sized,
+        {
+            Ok([a + b])
+        }
+    }
+
+    #[test]
+    fn test_select() {
+        let population = [0, 1, 2, 3, 4];
+        let individual = population.select(LastTwo.recombine(Add)).unwrap()[0];
+
+        assert_eq!(individual, 7);
+    }
+}


### PR DESCRIPTION
This adds a `Recombine` selector that recombines the output of another selector.

The role of a `Selector` in this project does not completely align with what a selector represents in evolutionary computation as it takes on a larger role of describing the entire genetic operator flow. Rather than selecting an existing individual it instead provides a new individual, regardless of whether it was from the original population or has since been mutated. The `Mutate` selector takes the output of one selector and mutates it with the given mutator. The same ability should be applied to recombinators.

This change simply introduces the `Recombine` selector that composes a selector with a recombinator to produce a new selector. It also provides the `Selector::recombine` method to allow chaining selectors and recombinators.