### PR TITLE
Add `Add` mutator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,11 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
 name = "brace-ec"
 version = "0.0.0"
 dependencies = [
  "array-util",
  "ghost",
+ "num-traits",
  "rand",
  "thiserror",
 ]
@@ -66,6 +73,15 @@ name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "ppv-lite86"

--- a/packages/brace-ec/Cargo.toml
+++ b/packages/brace-ec/Cargo.toml
@@ -11,5 +11,6 @@ edition = "2021"
 [dependencies]
 array-util = "1.0.2"
 ghost = "0.1.18"
+num-traits = "0.2.19"
 rand = "0.8.5"
 thiserror = "2.0.9"

--- a/packages/brace-ec/src/core/operator/mutator/add.rs
+++ b/packages/brace-ec/src/core/operator/mutator/add.rs
@@ -1,0 +1,69 @@
+use num_traits::{CheckedAdd, One};
+use rand::Rng;
+use thiserror::Error;
+
+use crate::core::individual::Individual;
+
+use super::Mutator;
+
+#[derive(Clone, Copy, Debug)]
+pub struct Add<I: Individual>(pub I);
+
+impl<I> Mutator for Add<I>
+where
+    I: Individual + CheckedAdd,
+{
+    type Individual = I;
+    type Error = AddError;
+
+    fn mutate<R>(
+        &self,
+        individual: Self::Individual,
+        _: &mut R,
+    ) -> Result<Self::Individual, Self::Error>
+    where
+        R: Rng + ?Sized,
+    {
+        individual.checked_add(&self.0).ok_or(AddError::Overflow)
+    }
+}
+
+impl<I> Default for Add<I>
+where
+    I: Individual + One,
+{
+    fn default() -> Self {
+        Self(I::one())
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum AddError {
+    #[error("addition would overflow")]
+    Overflow,
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::thread_rng;
+
+    use crate::core::operator::mutator::add::AddError;
+    use crate::core::operator::mutator::Mutator;
+
+    use super::Add;
+
+    #[test]
+    fn test_mutate() {
+        let mut rng = thread_rng();
+
+        let a = Add(1).mutate(1, &mut rng);
+        let b = Add(2).mutate(3, &mut rng);
+        let c = Add::default().mutate(5, &mut rng);
+        let d = Add(1).mutate(i32::MAX, &mut rng);
+
+        assert_eq!(a, Ok(2));
+        assert_eq!(b, Ok(5));
+        assert_eq!(c, Ok(6));
+        assert_eq!(d, Err(AddError::Overflow));
+    }
+}

--- a/packages/brace-ec/src/core/operator/mutator/mod.rs
+++ b/packages/brace-ec/src/core/operator/mutator/mod.rs
@@ -1,3 +1,5 @@
+pub mod add;
+
 use rand::Rng;
 
 use crate::core::individual::Individual;

--- a/packages/brace-ec/src/core/operator/selector/mutate.rs
+++ b/packages/brace-ec/src/core/operator/selector/mutate.rs
@@ -53,45 +53,22 @@ pub enum MutateError<S, M> {
 
 #[cfg(test)]
 mod tests {
-    use std::convert::Infallible;
-    use std::ops::Add;
-
-    use rand::Rng;
-
-    use crate::core::operator::mutator::Mutator;
+    use crate::core::operator::mutator::add::Add;
     use crate::core::operator::selector::first::First;
     use crate::core::operator::selector::Selector;
     use crate::core::population::Population;
 
-    struct Increment;
-
-    impl Mutator for Increment {
-        type Individual = u8;
-        type Error = Infallible;
-
-        fn mutate<R>(
-            &self,
-            individual: Self::Individual,
-            _: &mut R,
-        ) -> Result<Self::Individual, Self::Error>
-        where
-            R: Rng + ?Sized,
-        {
-            Ok(individual.add(1))
-        }
-    }
-
     #[test]
     fn test_mutate_selector() {
         let population = [0];
-        let individual = population.select(First.mutate(Increment)).unwrap()[0];
+        let individual = population.select(First.mutate(Add(1))).unwrap()[0];
 
         assert_eq!(individual, 1);
 
         let individual = population
-            .select(First.mutate(Increment).mutate(Increment))
+            .select(First.mutate(Add(2)).mutate(Add(3)))
             .unwrap()[0];
 
-        assert_eq!(individual, 2);
+        assert_eq!(individual, 5);
     }
 }


### PR DESCRIPTION
This adds a new `Add` mutator that adds a number to another number.

The project currently has a lack of simple operators that can be used in examples and tests so many tests implement custom operators instead. This adds extra boilerplate where an existing operator would be more useful. The various numeric scalar types were updated in #8 to implement `Individual` so these are good candidates for simple tests.

This change introduces a new `Add` mutator to add a predefined individual to the input individual. It does so through the use of the `CheckedAdd` trait from the `num-traits` crate which is implemented for the standard integer types. This is not particularly useful outside of tests and examples but it is beneficial to include. This also updates the mutate selector tests to use the new mutator instead of defining a custom one.