### PR TITLE
Add `Sum` recombinator

### DIFF
--- a/packages/brace-ec/src/core/operator/recombinator/mod.rs
+++ b/packages/brace-ec/src/core/operator/recombinator/mod.rs
@@ -1,3 +1,5 @@
+pub mod sum;
+
 use rand::Rng;
 
 use crate::core::population::Population;

--- a/packages/brace-ec/src/core/operator/recombinator/sum.rs
+++ b/packages/brace-ec/src/core/operator/recombinator/sum.rs
@@ -1,0 +1,55 @@
+use rand::Rng;
+use thiserror::Error;
+
+use crate::core::population::Population;
+use crate::util::sum::CheckedSum;
+
+use super::Recombinator;
+
+#[ghost::phantom]
+#[derive(Clone, Copy, Debug)]
+pub struct Sum<P: Population>;
+
+impl<P> Recombinator for Sum<P>
+where
+    P: Population + CheckedSum<P::Individual>,
+{
+    type Parents = P;
+    type Output = [P::Individual; 1];
+    type Error = SumError;
+
+    fn recombine<R>(&self, parents: Self::Parents, _: &mut R) -> Result<Self::Output, Self::Error>
+    where
+        R: Rng + ?Sized,
+    {
+        Ok([parents.checked_sum().ok_or(SumError::Overflow)?])
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum SumError {
+    #[error("summation would overflow")]
+    Overflow,
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::thread_rng;
+
+    use crate::core::operator::recombinator::Recombinator;
+
+    use super::{Sum, SumError};
+
+    #[test]
+    fn test_recombine() {
+        let mut rng = thread_rng();
+
+        let a = Sum.recombine([0, 0], &mut rng);
+        let b = Sum.recombine([1, 2], &mut rng);
+        let c = Sum.recombine([1, i32::MAX], &mut rng);
+
+        assert_eq!(a, Ok([0]));
+        assert_eq!(b, Ok([3]));
+        assert_eq!(c, Err(SumError::Overflow));
+    }
+}

--- a/packages/brace-ec/src/core/operator/selector/recombine.rs
+++ b/packages/brace-ec/src/core/operator/selector/recombine.rs
@@ -61,7 +61,7 @@ mod tests {
 
     use rand::Rng;
 
-    use crate::core::operator::recombinator::Recombinator;
+    use crate::core::operator::recombinator::sum::Sum;
     use crate::core::operator::selector::Selector;
     use crate::core::population::Population;
 
@@ -84,29 +84,10 @@ mod tests {
         }
     }
 
-    struct Add;
-
-    impl Recombinator for Add {
-        type Parents = [u8; 2];
-        type Output = [u8; 1];
-        type Error = Infallible;
-
-        fn recombine<R>(
-            &self,
-            [a, b]: Self::Parents,
-            _: &mut R,
-        ) -> Result<Self::Output, Self::Error>
-        where
-            R: Rng + ?Sized,
-        {
-            Ok([a + b])
-        }
-    }
-
     #[test]
     fn test_select() {
         let population = [0, 1, 2, 3, 4];
-        let individual = population.select(LastTwo.recombine(Add)).unwrap()[0];
+        let individual = population.select(LastTwo.recombine(Sum)).unwrap()[0];
 
         assert_eq!(individual, 7);
     }

--- a/packages/brace-ec/src/util/mod.rs
+++ b/packages/brace-ec/src/util/mod.rs
@@ -1,2 +1,3 @@
 pub mod iter;
 pub mod map;
+pub mod sum;

--- a/packages/brace-ec/src/util/sum.rs
+++ b/packages/brace-ec/src/util/sum.rs
@@ -1,0 +1,18 @@
+use num_traits::{CheckedAdd, Zero};
+
+use super::iter::Iterable;
+
+pub trait CheckedSum<T> {
+    fn checked_sum(&self) -> Option<T>;
+}
+
+impl<T, I> CheckedSum<T> for I
+where
+    T: CheckedAdd + Zero,
+    I: Iterable<Item = T>,
+{
+    fn checked_sum(&self) -> Option<T> {
+        self.iter()
+            .try_fold(T::zero(), |acc, value| acc.checked_add(value))
+    }
+}


### PR DESCRIPTION
This adds a new `Sum` recombinator to add individuals together.

The previous update #15 added a new `Add` mutator that adds a fixed number to an individual. This was a simple operator that could be used in tests and examples. The same should be done for recombinators that works with the `Add` mutator.

This change simply introduces a new `Sum` recombinator using a utility `CheckedSum` trait. The `num-traits` crate does not provide a `CheckedSum` trait and the standard `Sum` trait is also not checked. Therefore for consistency a new utility trait was added with a blanket implementation using `CheckedAdd`. This also updates the recombine selector tests to use the new recombinator instead of defining a custom one.