### PR TITLE
Add `Invert` mutator

### DIFF
--- a/packages/brace-ec/src/core/operator/mutator/invert.rs
+++ b/packages/brace-ec/src/core/operator/mutator/invert.rs
@@ -1,0 +1,51 @@
+use std::convert::Infallible;
+use std::ops::Not;
+
+use rand::Rng;
+
+use crate::core::individual::Individual;
+
+use super::Mutator;
+
+#[ghost::phantom]
+#[derive(Clone, Copy, Debug)]
+pub struct Invert<I: Individual>;
+
+impl<I> Mutator for Invert<I>
+where
+    I: Individual + Not<Output = I>,
+{
+    type Individual = I;
+    type Error = Infallible;
+
+    fn mutate<R>(
+        &self,
+        individual: Self::Individual,
+        _: &mut R,
+    ) -> Result<Self::Individual, Self::Error>
+    where
+        R: Rng + ?Sized,
+    {
+        Ok(individual.not())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::thread_rng;
+
+    use crate::core::operator::mutator::Mutator;
+
+    use super::Invert;
+
+    #[test]
+    fn test_mutate() {
+        let mut rng = thread_rng();
+
+        let a = Invert.mutate(true, &mut rng).unwrap();
+        let b = Invert.mutate(false, &mut rng).unwrap();
+
+        assert!(!a);
+        assert!(b);
+    }
+}

--- a/packages/brace-ec/src/core/operator/mutator/mod.rs
+++ b/packages/brace-ec/src/core/operator/mutator/mod.rs
@@ -1,4 +1,5 @@
 pub mod add;
+pub mod invert;
 
 use rand::Rng;
 


### PR DESCRIPTION
This adds a new `Invert` mutator to invert an individual.

Various scalar types including `bool` and integers support being inverted via the `!` logical negation operator and `Not` trait behind it. This allows the type to be inverted and some evolution operators would find this useful.

This change adds a simple implementation of the `Invert` mutator using the `Not` trait. Unfortunately this is not implemented for collections such as vectors or arrays and so it may be better to use a custom trait instead as it would be more flexible. This could easily be changed in the future but for now the simple implementation is best. It may be possible to leverage a new `Each` type that mutates an individual as a population to achieve the same effect.