### PR TITLE
Add `Rate` mutator adapter

### DIFF
--- a/packages/brace-ec/src/core/operator/mutator/mod.rs
+++ b/packages/brace-ec/src/core/operator/mutator/mod.rs
@@ -1,9 +1,12 @@
 pub mod add;
 pub mod invert;
+pub mod rate;
 
 use rand::Rng;
 
 use crate::core::individual::Individual;
+
+use self::rate::Rate;
 
 use super::repeat::Repeat;
 
@@ -18,6 +21,13 @@ pub trait Mutator: Sized {
     ) -> Result<Self::Individual, Self::Error>
     where
         R: Rng + ?Sized;
+
+    fn rate(self, rate: f64) -> Rate<Self>
+    where
+        Self: Sized,
+    {
+        Rate::new(self, rate)
+    }
 
     fn repeat(self, count: usize) -> Repeat<Self>
     where

--- a/packages/brace-ec/src/core/operator/mutator/rate.rs
+++ b/packages/brace-ec/src/core/operator/mutator/rate.rs
@@ -1,0 +1,53 @@
+use rand::Rng;
+
+use super::Mutator;
+
+pub struct Rate<M> {
+    mutator: M,
+    rate: f64,
+}
+
+impl<M> Rate<M> {
+    pub fn new(mutator: M, rate: f64) -> Self {
+        Self { mutator, rate }
+    }
+}
+
+impl<M> Mutator for Rate<M>
+where
+    M: Mutator,
+{
+    type Individual = M::Individual;
+    type Error = M::Error;
+
+    fn mutate<R>(
+        &self,
+        individual: Self::Individual,
+        rng: &mut R,
+    ) -> Result<Self::Individual, Self::Error>
+    where
+        R: Rng + ?Sized,
+    {
+        if rng.gen_bool(self.rate) {
+            self.mutator.mutate(individual, rng)
+        } else {
+            Ok(individual)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::individual::Individual;
+    use crate::core::operator::mutator::add::Add;
+    use crate::core::operator::mutator::Mutator;
+
+    #[test]
+    fn test_mutate() {
+        let a = 1.mutate(Add(1).rate(1.0)).unwrap();
+        let b = 1.mutate(Add(1).rate(0.0)).unwrap();
+
+        assert_eq!(a, 2);
+        assert_eq!(b, 1);
+    }
+}


### PR DESCRIPTION
This adds a new `Rate` mutator adapter to adjust the rate of mutation.

Many mutation operators need to be applied at specific rates to slow down the rate of mutation. This could be applied to individual mutators but it makes more sense to extract this logic into a common adapter.

This changes introduces the `Rate` mutator adapter and adds a new `rate` method to the `Mutator` trait to allow existing mutators to be easily adapted. There are currently no limitations on the specified rate so only values between 0.0 and 1.0 are valid otherwise the program will panic.

A more sophisticated implementation would be to use the `Bernoulli` distribution but that would require the operator constructor to be fallible or to store a result instead and return a copy of the error if invalid. For now the current implementation works well enough.