### PR TITLE
Add `Chromosome` trait

### DIFF
--- a/packages/brace-ec/src/lib.rs
+++ b/packages/brace-ec/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod core;
+pub mod linear;
 pub mod util;

--- a/packages/brace-ec/src/linear/chromosome.rs
+++ b/packages/brace-ec/src/linear/chromosome.rs
@@ -1,0 +1,61 @@
+pub trait Chromosome {
+    type Gene;
+
+    fn gene(&self, index: usize) -> Option<&Self::Gene>;
+
+    fn gene_mut(&mut self, index: usize) -> Option<&mut Self::Gene>;
+
+    fn len(&self) -> usize;
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl<T> Chromosome for Vec<T> {
+    type Gene = T;
+
+    fn gene(&self, index: usize) -> Option<&Self::Gene> {
+        self.get(index)
+    }
+
+    fn gene_mut(&mut self, index: usize) -> Option<&mut Self::Gene> {
+        self.get_mut(index)
+    }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<T, const N: usize> Chromosome for [T; N] {
+    type Gene = T;
+
+    fn gene(&self, index: usize) -> Option<&Self::Gene> {
+        self.get(index)
+    }
+
+    fn gene_mut(&mut self, index: usize) -> Option<&mut Self::Gene> {
+        self.get_mut(index)
+    }
+
+    fn len(&self) -> usize {
+        N
+    }
+}
+
+impl<T> Chromosome for [T] {
+    type Gene = T;
+
+    fn gene(&self, index: usize) -> Option<&Self::Gene> {
+        self.get(index)
+    }
+
+    fn gene_mut(&mut self, index: usize) -> Option<&mut Self::Gene> {
+        self.get_mut(index)
+    }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+}

--- a/packages/brace-ec/src/linear/mod.rs
+++ b/packages/brace-ec/src/linear/mod.rs
@@ -1,0 +1,1 @@
+pub mod chromosome;


### PR DESCRIPTION
This adds a new `Chromosome` trait for individual genomes that are represented by a collection of genes.

The `Individual` trait is implemented on vectors and arrays but there are not yet any operators to act on items in the collection. The first step toward that is to define a common interface for these collections.

This simply adds a new `Chromosome` trait under a new `linear` module with implementations for arrays, vectors and slices. This is very similar to the `Individual` and `Population` traits.