### PR TITLE
Add `Crossover` trait

### DIFF
--- a/packages/brace-ec/src/linear/crossover.rs
+++ b/packages/brace-ec/src/linear/crossover.rs
@@ -1,0 +1,138 @@
+use std::mem;
+use std::ops::RangeBounds;
+
+use crate::util::range::{get_range_to, get_slice_range_mut};
+
+use super::chromosome::Chromosome;
+
+pub trait Crossover: Chromosome {
+    fn crossover_gene(&mut self, other: &mut Self, index: usize);
+
+    fn crossover_segment<R>(&mut self, other: &mut Self, range: R)
+    where
+        R: RangeBounds<usize>,
+    {
+        for index in get_range_to(range, self.len()) {
+            self.crossover_gene(other, index);
+        }
+    }
+}
+
+impl<T> Crossover for Vec<T> {
+    fn crossover_gene(&mut self, other: &mut Self, index: usize) {
+        self.as_mut_slice()
+            .crossover_gene(other.as_mut_slice(), index);
+    }
+
+    fn crossover_segment<R>(&mut self, other: &mut Self, range: R)
+    where
+        R: RangeBounds<usize>,
+    {
+        self.as_mut_slice()
+            .crossover_segment(other.as_mut_slice(), range);
+    }
+}
+
+impl<T, const N: usize> Crossover for [T; N] {
+    fn crossover_gene(&mut self, other: &mut Self, index: usize) {
+        self.as_mut_slice()
+            .crossover_gene(other.as_mut_slice(), index);
+    }
+
+    fn crossover_segment<R>(&mut self, other: &mut Self, range: R)
+    where
+        R: RangeBounds<usize>,
+    {
+        self.as_mut_slice()
+            .crossover_segment(other.as_mut_slice(), range);
+    }
+}
+
+impl<T> Crossover for [T] {
+    fn crossover_gene(&mut self, other: &mut Self, index: usize) {
+        if let (Some(lhs), Some(rhs)) = (self.get_mut(index), other.get_mut(index)) {
+            mem::swap(lhs, rhs)
+        }
+    }
+
+    fn crossover_segment<R>(&mut self, other: &mut Self, range: R)
+    where
+        R: RangeBounds<usize>,
+    {
+        let lhs = get_slice_range_mut(self, &range);
+        let rhs = get_slice_range_mut(other, &range);
+
+        lhs.swap_with_slice(rhs);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Crossover;
+
+    #[test]
+    fn test_array() {
+        let mut a = [0, 1, 2, 3, 4];
+        let mut b = [5, 6, 7, 8, 9];
+
+        a.crossover_gene(&mut b, 0);
+        b.crossover_gene(&mut a, 4);
+
+        assert_eq!(a, [5, 1, 2, 3, 9]);
+        assert_eq!(b, [0, 6, 7, 8, 4]);
+
+        a.crossover_segment(&mut b, 1..3);
+
+        assert_eq!(a, [5, 6, 7, 3, 9]);
+        assert_eq!(b, [0, 1, 2, 8, 4]);
+
+        b.crossover_segment(&mut a, 0..=4);
+
+        assert_eq!(a, [0, 1, 2, 8, 4]);
+        assert_eq!(b, [5, 6, 7, 3, 9]);
+    }
+
+    #[test]
+    fn test_vec() {
+        let mut a = vec![0, 1, 2, 3, 4];
+        let mut b = vec![5, 6, 7, 8, 9];
+
+        a.crossover_gene(&mut b, 0);
+        b.crossover_gene(&mut a, 4);
+
+        assert_eq!(a, [5, 1, 2, 3, 9]);
+        assert_eq!(b, [0, 6, 7, 8, 4]);
+
+        a.crossover_segment(&mut b, 1..3);
+
+        assert_eq!(a, [5, 6, 7, 3, 9]);
+        assert_eq!(b, [0, 1, 2, 8, 4]);
+
+        b.crossover_segment(&mut a, 0..=4);
+
+        assert_eq!(a, [0, 1, 2, 8, 4]);
+        assert_eq!(b, [5, 6, 7, 3, 9]);
+    }
+
+    #[test]
+    fn test_slice() {
+        let mut a = [0, 1, 2, 3, 4];
+        let mut b = [5, 6, 7, 8, 9];
+
+        a.as_mut_slice().crossover_gene(b.as_mut_slice(), 0);
+        b.as_mut_slice().crossover_gene(a.as_mut_slice(), 4);
+
+        assert_eq!(a, [5, 1, 2, 3, 9]);
+        assert_eq!(b, [0, 6, 7, 8, 4]);
+
+        a.as_mut_slice().crossover_segment(b.as_mut_slice(), 1..3);
+
+        assert_eq!(a, [5, 6, 7, 3, 9]);
+        assert_eq!(b, [0, 1, 2, 8, 4]);
+
+        b.as_mut_slice().crossover_segment(a.as_mut_slice(), 0..=4);
+
+        assert_eq!(a, [0, 1, 2, 8, 4]);
+        assert_eq!(b, [5, 6, 7, 3, 9]);
+    }
+}

--- a/packages/brace-ec/src/linear/mod.rs
+++ b/packages/brace-ec/src/linear/mod.rs
@@ -1,1 +1,2 @@
 pub mod chromosome;
+pub mod crossover;

--- a/packages/brace-ec/src/util/mod.rs
+++ b/packages/brace-ec/src/util/mod.rs
@@ -1,3 +1,4 @@
 pub mod iter;
 pub mod map;
+pub mod range;
 pub mod sum;

--- a/packages/brace-ec/src/util/range.rs
+++ b/packages/brace-ec/src/util/range.rs
@@ -1,0 +1,47 @@
+use std::ops::{Bound, Range, RangeBounds};
+
+pub fn get_range_to<R>(range: R, max: usize) -> Range<usize>
+where
+    R: RangeBounds<usize>,
+{
+    match range.start_bound() {
+        Bound::Included(&start) => match range.end_bound() {
+            Bound::Included(&end) => start..((end + 1).min(max)),
+            Bound::Excluded(&end) => start..((end).min(max)),
+            Bound::Unbounded => start..max,
+        },
+        Bound::Excluded(&start) => match range.end_bound() {
+            Bound::Included(&end) => (start + 1)..((end + 1).min(max)),
+            Bound::Excluded(&end) => (start + 1)..(end.min(max)),
+            Bound::Unbounded => (start + 1)..max,
+        },
+        Bound::Unbounded => match range.end_bound() {
+            Bound::Included(&end) => 0..(end.min(max)),
+            Bound::Excluded(&end) => 0..(end.min(max)),
+            Bound::Unbounded => 0..max,
+        },
+    }
+}
+
+pub fn get_slice_range_mut<'a, T, R>(input: &'a mut [T], range: &R) -> &'a mut [T]
+where
+    R: RangeBounds<usize>,
+{
+    match range.start_bound() {
+        Bound::Included(&start) => match range.end_bound() {
+            Bound::Included(&end) => &mut input[start..=end],
+            Bound::Excluded(&end) => &mut input[start..end],
+            Bound::Unbounded => &mut input[start..],
+        },
+        Bound::Excluded(&start) => match range.end_bound() {
+            Bound::Included(&end) => &mut input[(start + 1)..=end],
+            Bound::Excluded(&end) => &mut input[(start + 1)..end],
+            Bound::Unbounded => &mut input[(start + 1)..],
+        },
+        Bound::Unbounded => match range.end_bound() {
+            Bound::Included(&end) => &mut input[..=end],
+            Bound::Excluded(&end) => &mut input[..end],
+            Bound::Unbounded => input,
+        },
+    }
+}


### PR DESCRIPTION
This adds a new `Crossover` trait that extends `Chromosome` with the ability to crossover genes and segments.

There are various crossover recombinators in evolutionary computation that require the ability to swap individual genes and gene segments in a chromosome. This functionality should be encapsulated in a new trait.

This change simply adds a new `Crossover` trait with implementations for arrays, vectors and slices. It also includes two new range utility functions to convert from a generic range to an inclusive-exclusive range. There might be a better solution that avoids these helper functions but there isn't anything obvious in the `RangeBounds` API that doesn't involve using the `Index` traits.