### PR TITLE
Add `TwoPointCrossover` recombinator

### DIFF
--- a/packages/brace-ec/src/linear/operator/recombinator/point.rs
+++ b/packages/brace-ec/src/linear/operator/recombinator/point.rs
@@ -43,6 +43,44 @@ where
     }
 }
 
+#[ghost::phantom]
+#[derive(Clone, Copy, Debug)]
+pub struct TwoPointCrossover<P: Population>;
+
+impl<I> Recombinator for TwoPointCrossover<[I; 2]>
+where
+    I: Individual<Genome: Crossover>,
+{
+    type Parents = [I; 2];
+    type Output = [I; 2];
+    type Error = PointCrossoverError;
+
+    fn recombine<R>(
+        &self,
+        [mut lhs, mut rhs]: Self::Parents,
+        rng: &mut R,
+    ) -> Result<Self::Output, Self::Error>
+    where
+        R: Rng + ?Sized,
+    {
+        if lhs.genome().len() != rhs.genome().len() {
+            return Err(PointCrossoverError::MixedLength);
+        }
+
+        if lhs.genome().len() < 2 {
+            return Err(PointCrossoverError::TooManySegments);
+        }
+
+        let a = rng.gen_range(0..lhs.genome().len());
+        let b = rng.gen_range(0..lhs.genome().len());
+
+        lhs.genome_mut()
+            .crossover_segment(rhs.genome_mut(), a.min(b)..b.max(a));
+
+        Ok([lhs, rhs])
+    }
+}
+
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum PointCrossoverError {
     #[error("unsupported crossover between genomes of different lengths")]
@@ -55,7 +93,7 @@ pub enum PointCrossoverError {
 mod tests {
     use crate::core::operator::recombinator::Recombinator;
 
-    use super::{OnePointCrossover, PointCrossoverError};
+    use super::{OnePointCrossover, PointCrossoverError, TwoPointCrossover};
 
     #[test]
     fn test_recombine_one_point() {
@@ -92,6 +130,45 @@ mod tests {
         let lhs = Vec::<i32>::new();
         let rhs = Vec::<i32>::new();
         let res = OnePointCrossover.recombine([lhs, rhs], &mut rng);
+
+        assert_eq!(res, Err(PointCrossoverError::TooManySegments));
+    }
+
+    #[test]
+    fn test_recombine_two_point() {
+        let mut rng = rand::thread_rng();
+
+        let lhs = [true, true, true, true, true];
+        let rhs = [false, false, false, false, false];
+
+        let [l, r] = TwoPointCrossover.recombine([lhs, rhs], &mut rng).unwrap();
+
+        assert!(l
+            .iter()
+            .all(|gene| lhs.contains(gene) || rhs.contains(gene)));
+        assert!(r
+            .iter()
+            .all(|gene| lhs.contains(gene) || rhs.contains(gene)));
+    }
+
+    #[test]
+    fn test_recombine_two_point_mixed_length() {
+        let mut rng = rand::thread_rng();
+
+        let lhs = vec![true, true];
+        let rhs = vec![false, false, false];
+        let res = TwoPointCrossover.recombine([lhs, rhs], &mut rng);
+
+        assert_eq!(res, Err(PointCrossoverError::MixedLength));
+    }
+
+    #[test]
+    fn test_recombine_two_point_too_many_segments() {
+        let mut rng = rand::thread_rng();
+
+        let lhs = vec![1];
+        let rhs = vec![1];
+        let res = TwoPointCrossover.recombine([lhs, rhs], &mut rng);
 
         assert_eq!(res, Err(PointCrossoverError::TooManySegments));
     }


### PR DESCRIPTION
This adds a new `TwoPointCrossover` recombinator.

Two-point crossover is another common recombinator in evolutionary computation that selects a segment between two points to swap instead of a segment from or to a single point.

This change simply introduces a new `TwoPointCrossover` recombinator based on the `OnePointCrossover` recombinator but including a second point.