### PR TITLE
Add `MultiPointCrossover` recombinator

### DIFF
--- a/packages/brace-ec/src/linear/operator/recombinator/point.rs
+++ b/packages/brace-ec/src/linear/operator/recombinator/point.rs
@@ -1,3 +1,6 @@
+use std::marker::PhantomData;
+
+use rand::seq::IteratorRandom;
 use rand::Rng;
 use thiserror::Error;
 
@@ -35,9 +38,10 @@ where
             return Err(PointCrossoverError::TooManySegments);
         }
 
-        let i = rng.gen_range(0..lhs.genome().len());
+        let point = rng.gen_range(0..lhs.genome().len());
 
-        lhs.genome_mut().crossover_segment(rhs.genome_mut(), 0..i);
+        lhs.genome_mut()
+            .crossover_segment(rhs.genome_mut(), point..);
 
         Ok([lhs, rhs])
     }
@@ -81,6 +85,65 @@ where
     }
 }
 
+pub struct MultiPointCrossover<P: Population> {
+    count: usize,
+    marker: PhantomData<fn() -> P>,
+}
+
+impl<P> MultiPointCrossover<P>
+where
+    P: Population,
+{
+    pub fn new(count: usize) -> Self {
+        Self {
+            count,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<I> Recombinator for MultiPointCrossover<[I; 2]>
+where
+    I: Individual<Genome: Crossover>,
+{
+    type Parents = [I; 2];
+    type Output = [I; 2];
+    type Error = PointCrossoverError;
+
+    fn recombine<R>(&self, parents: Self::Parents, rng: &mut R) -> Result<Self::Output, Self::Error>
+    where
+        R: Rng + ?Sized,
+    {
+        match self.count {
+            0 => Ok(parents),
+            1 => OnePointCrossover.recombine(parents, rng),
+            2 => TwoPointCrossover.recombine(parents, rng),
+            n => {
+                let [mut lhs, mut rhs] = parents;
+
+                if lhs.genome().len() != rhs.genome().len() {
+                    return Err(PointCrossoverError::MixedLength);
+                }
+
+                if lhs.genome().len() < n {
+                    return Err(PointCrossoverError::TooManySegments);
+                }
+
+                let mut points = (0..lhs.genome().len()).choose_multiple(rng, n);
+
+                points.sort();
+
+                for point in points {
+                    lhs.genome_mut()
+                        .crossover_segment(rhs.genome_mut(), point..);
+                }
+
+                Ok([lhs, rhs])
+            }
+        }
+    }
+}
+
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum PointCrossoverError {
     #[error("unsupported crossover between genomes of different lengths")]
@@ -93,7 +156,7 @@ pub enum PointCrossoverError {
 mod tests {
     use crate::core::operator::recombinator::Recombinator;
 
-    use super::{OnePointCrossover, PointCrossoverError, TwoPointCrossover};
+    use super::{MultiPointCrossover, OnePointCrossover, PointCrossoverError, TwoPointCrossover};
 
     #[test]
     fn test_recombine_one_point() {
@@ -171,5 +234,60 @@ mod tests {
         let res = TwoPointCrossover.recombine([lhs, rhs], &mut rng);
 
         assert_eq!(res, Err(PointCrossoverError::TooManySegments));
+    }
+
+    #[test]
+    fn test_recombine_multi_point() {
+        let mut rng = rand::thread_rng();
+
+        let lhs = [true, true, true, true, true, true, true];
+        let rhs = [false, false, false, false, false, false, false];
+
+        let [l, r] = MultiPointCrossover::new(3)
+            .recombine([lhs, rhs], &mut rng)
+            .unwrap();
+
+        assert!(l
+            .iter()
+            .all(|gene| lhs.contains(gene) || rhs.contains(gene)));
+        assert!(r
+            .iter()
+            .all(|gene| lhs.contains(gene) || rhs.contains(gene)));
+    }
+
+    #[test]
+    fn test_recombine_multi_point_mixed_length() {
+        let mut rng = rand::thread_rng();
+
+        let lhs = vec![true, true, true, true];
+        let rhs = vec![false, false, false, false, false];
+        let res = MultiPointCrossover::new(3).recombine([lhs, rhs], &mut rng);
+
+        assert_eq!(res, Err(PointCrossoverError::MixedLength));
+    }
+
+    #[test]
+    fn test_recombine_multi_point_too_many_segments() {
+        let mut rng = rand::thread_rng();
+
+        let lhs = [true, true, true, true, true];
+        let rhs = [false, false, false, false, false];
+        let res = MultiPointCrossover::new(6).recombine([lhs, rhs], &mut rng);
+
+        assert_eq!(res, Err(PointCrossoverError::TooManySegments));
+    }
+
+    #[test]
+    fn test_recombine_multi_point_uniform() {
+        let mut rng = rand::thread_rng();
+
+        let lhs = [true, true, true, true, true, true];
+        let rhs = [false, false, false, false, false, false];
+        let [l, r] = MultiPointCrossover::new(6)
+            .recombine([lhs, rhs], &mut rng)
+            .unwrap();
+
+        assert_eq!(l, [false, true, false, true, false, true]);
+        assert_eq!(r, [true, false, true, false, true, false]);
     }
 }


### PR DESCRIPTION
This adds a new `MultiPointCrossover` recombinator to support crossovers with more than 2 points.

A k-point crossover is a generalised version of a 2-point crossover which can be thought of as multiple 1-point crossovers at different points.

This change introduces a new `MultiPointCrossover` recombinator that takes a number of points and either delegates to the 1-point and 2-point recombinators or repeatedly does 1-point crossover depending on the input. This also tweaks the `OnePointCrossover` logic to swap the second segment and not the first for consistency with the new recombinator.