### PR TITLE
Add `Inspect` operator adapter

### DIFF
--- a/packages/brace-ec/src/core/operator/evolver/mod.rs
+++ b/packages/brace-ec/src/core/operator/evolver/mod.rs
@@ -2,6 +2,7 @@ pub mod select;
 
 use crate::core::generation::Generation;
 
+use super::inspect::Inspect;
 use super::repeat::Repeat;
 
 pub trait Evolver {
@@ -15,5 +16,13 @@ pub trait Evolver {
         Self: Sized,
     {
         Repeat::new(self, count)
+    }
+
+    fn inspect<F>(self, inspector: F) -> Inspect<Self, F>
+    where
+        F: Fn(&Self::Generation),
+        Self: Sized,
+    {
+        Inspect::new(self, inspector)
     }
 }

--- a/packages/brace-ec/src/core/operator/inspect.rs
+++ b/packages/brace-ec/src/core/operator/inspect.rs
@@ -1,0 +1,144 @@
+use rand::Rng;
+
+use super::evolver::Evolver;
+use super::mutator::Mutator;
+use super::recombinator::Recombinator;
+use super::selector::Selector;
+
+pub struct Inspect<T, F> {
+    operator: T,
+    inspector: F,
+}
+
+impl<T, F> Inspect<T, F> {
+    pub fn new(operator: T, inspector: F) -> Self {
+        Self {
+            operator,
+            inspector,
+        }
+    }
+}
+
+impl<T, F> Selector for Inspect<T, F>
+where
+    T: Selector,
+    F: Fn(&T::Output),
+{
+    type Population = T::Population;
+    type Output = T::Output;
+    type Error = T::Error;
+
+    fn select<R>(
+        &self,
+        population: &Self::Population,
+        rng: &mut R,
+    ) -> Result<Self::Output, Self::Error>
+    where
+        R: Rng + ?Sized,
+    {
+        self.operator
+            .select(population, rng)
+            .inspect(|output| (self.inspector)(output))
+    }
+}
+
+impl<T, F> Mutator for Inspect<T, F>
+where
+    T: Mutator,
+    F: Fn(&T::Individual),
+{
+    type Individual = T::Individual;
+    type Error = T::Error;
+
+    fn mutate<R>(
+        &self,
+        individual: Self::Individual,
+        rng: &mut R,
+    ) -> Result<Self::Individual, Self::Error>
+    where
+        R: Rng + ?Sized,
+    {
+        self.operator
+            .mutate(individual, rng)
+            .inspect(|individual| (self.inspector)(individual))
+    }
+}
+
+impl<T, F> Recombinator for Inspect<T, F>
+where
+    T: Recombinator,
+    F: Fn(&T::Output),
+{
+    type Parents = T::Parents;
+    type Output = T::Output;
+    type Error = T::Error;
+
+    fn recombine<R>(&self, parents: Self::Parents, rng: &mut R) -> Result<Self::Output, Self::Error>
+    where
+        R: Rng + ?Sized,
+    {
+        self.operator
+            .recombine(parents, rng)
+            .inspect(|output| (self.inspector)(output))
+    }
+}
+
+impl<T, F> Evolver for Inspect<T, F>
+where
+    T: Evolver,
+    F: Fn(&T::Generation),
+{
+    type Generation = T::Generation;
+    type Error = T::Error;
+
+    fn evolve(&self, generation: Self::Generation) -> Result<Self::Generation, Self::Error> {
+        self.operator
+            .evolve(generation)
+            .inspect(|generation| (self.inspector)(generation))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::individual::Individual;
+    use crate::core::operator::evolver::select::Select;
+    use crate::core::operator::evolver::Evolver;
+    use crate::core::operator::mutator::add::Add;
+    use crate::core::operator::mutator::Mutator;
+    use crate::core::operator::recombinator::sum::Sum;
+    use crate::core::operator::recombinator::Recombinator;
+    use crate::core::operator::selector::first::First;
+    use crate::core::operator::selector::Selector;
+    use crate::core::population::Population;
+
+    #[test]
+    fn test_select() {
+        [0, 1, 2, 3, 4]
+            .select(First.inspect(|output| assert_eq!(output, &[0])))
+            .unwrap();
+    }
+
+    #[test]
+    fn test_mutate() {
+        1.mutate(Add(1).inspect(|individual| assert_eq!(individual, &2)))
+            .unwrap();
+    }
+
+    #[test]
+    fn test_recombine() {
+        [2, 2]
+            .recombine(Sum.inspect(|output| assert_eq!(output, &[4])))
+            .unwrap();
+    }
+
+    #[test]
+    fn test_evolve() {
+        Select::new(First)
+            .evolve((0, [0, 1, 2, 3, 4]))
+            .inspect(|(i, population)| {
+                assert_eq!(i, &1);
+                assert_eq!(population, &[0, 0, 0, 0, 0]);
+            })
+            .unwrap();
+    }
+}

--- a/packages/brace-ec/src/core/operator/mod.rs
+++ b/packages/brace-ec/src/core/operator/mod.rs
@@ -1,4 +1,5 @@
 pub mod evolver;
+pub mod inspect;
 pub mod mutator;
 pub mod recombinator;
 pub mod repeat;

--- a/packages/brace-ec/src/core/operator/mutator/mod.rs
+++ b/packages/brace-ec/src/core/operator/mutator/mod.rs
@@ -8,6 +8,7 @@ use crate::core::individual::Individual;
 
 use self::rate::Rate;
 
+use super::inspect::Inspect;
 use super::repeat::Repeat;
 
 pub trait Mutator: Sized {
@@ -34,5 +35,13 @@ pub trait Mutator: Sized {
         Self: Sized,
     {
         Repeat::new(self, count)
+    }
+
+    fn inspect<F>(self, inspector: F) -> Inspect<Self, F>
+    where
+        F: Fn(&Self::Individual),
+        Self: Sized,
+    {
+        Inspect::new(self, inspector)
     }
 }

--- a/packages/brace-ec/src/core/operator/recombinator/mod.rs
+++ b/packages/brace-ec/src/core/operator/recombinator/mod.rs
@@ -4,6 +4,7 @@ use rand::Rng;
 
 use crate::core::population::Population;
 
+use super::inspect::Inspect;
 use super::repeat::Repeat;
 
 pub trait Recombinator {
@@ -24,5 +25,13 @@ pub trait Recombinator {
         Self: Sized,
     {
         Repeat::new(self, count)
+    }
+
+    fn inspect<F>(self, inspector: F) -> Inspect<Self, F>
+    where
+        F: Fn(&Self::Output),
+        Self: Sized,
+    {
+        Inspect::new(self, inspector)
     }
 }

--- a/packages/brace-ec/src/core/operator/selector/mod.rs
+++ b/packages/brace-ec/src/core/operator/selector/mod.rs
@@ -10,6 +10,7 @@ use crate::core::population::Population;
 use self::mutate::Mutate;
 use self::recombine::Recombine;
 
+use super::inspect::Inspect;
 use super::mutator::Mutator;
 use super::recombinator::Recombinator;
 use super::repeat::Repeat;
@@ -46,5 +47,13 @@ pub trait Selector: Sized {
         Self: Sized,
     {
         Repeat::new(self, count)
+    }
+
+    fn inspect<F>(self, inspector: F) -> Inspect<Self, F>
+    where
+        F: Fn(&Self::Output),
+        Self: Sized,
+    {
+        Inspect::new(self, inspector)
     }
 }


### PR DESCRIPTION
This adds a new `Inspect` operator adapter to monitor operator flows.

The `Inspect` iterator adapter in the standard library can be used to monitor the process of iterators at different stages by providing a function or closure. This is useful because it allows to you debug or print the progress to better understand what it is doing. This would be a useful feature to bring to operators.

This change introduces a new `Inspect` operator with implementations of `Selector`, `Mutator`, `Recombinator` and `Evolver` that mimic the iterator adapter. This includes the `inspect` method on each of the operator traits to simplify operator chaining. The biggest difference here is that the adapter takes an `Fn` instead of a `FnMut` as the operators don't take `&mut self` and this limits the usefulness as the state cannot be mutated without interior mutability.