### PR TITLE
Add `Fitness` trait

### DIFF
--- a/packages/brace-ec/src/core/fitness.rs
+++ b/packages/brace-ec/src/core/fitness.rs
@@ -1,0 +1,36 @@
+use super::individual::Individual;
+
+pub trait Fitness: Individual {
+    type Value: Ord;
+
+    fn fitness(&self) -> Self::Value;
+}
+
+macro_rules! impl_fitness {
+    ($($type:path),+) => {
+        $(impl Fitness for $type {
+            type Value = Self;
+
+            fn fitness(&self) -> Self::Value {
+                *self
+            }
+        })+
+    };
+}
+
+impl_fitness!(u8, u16, u32, u64, u128, usize);
+impl_fitness!(i8, i16, i32, i64, i128, isize);
+
+#[cfg(test)]
+mod tests {
+    use super::Fitness;
+
+    #[test]
+    fn test_fitness() {
+        let a = 10_u8;
+        let b = 100_i32;
+
+        assert_eq!(a.fitness(), 10);
+        assert_eq!(b.fitness(), 100);
+    }
+}

--- a/packages/brace-ec/src/core/mod.rs
+++ b/packages/brace-ec/src/core/mod.rs
@@ -1,3 +1,4 @@
+pub mod fitness;
 pub mod generation;
 pub mod individual;
 pub mod operator;


### PR DESCRIPTION
This simply adds a new `Fitness` trait that is implemented on the standard integer types.

Evolutionary computation uses the term *fitness* to describe how good or successful an individual is or how likely it is to make it to the next generation. This is a key aspect of the system and allows better kinds of selectors to be created.

This change introduces a new `Fitness` trait that extends `Individual` to provide a `fitness` method. For the purposes of the project the fitness is a simple calculation or cached value and may rely on an external function to calculate and set the fitness but this is not covered here.