### PR TITLE
Implement `Fitness` for `Reverse`

### DIFF
--- a/packages/brace-ec/src/core/fitness.rs
+++ b/packages/brace-ec/src/core/fitness.rs
@@ -1,9 +1,22 @@
+use std::cmp::Reverse;
+
 use super::individual::Individual;
 
 pub trait Fitness: Individual {
     type Value: Ord;
 
     fn fitness(&self) -> Self::Value;
+}
+
+impl<T> Fitness for Reverse<T>
+where
+    T: Fitness,
+{
+    type Value = Reverse<T::Value>;
+
+    fn fitness(&self) -> Self::Value {
+        Reverse(self.0.fitness())
+    }
 }
 
 macro_rules! impl_fitness {
@@ -23,14 +36,18 @@ impl_fitness!(i8, i16, i32, i64, i128, isize);
 
 #[cfg(test)]
 mod tests {
+    use std::cmp::Reverse;
+
     use super::Fitness;
 
     #[test]
     fn test_fitness() {
         let a = 10_u8;
         let b = 100_i32;
+        let c = Reverse(50_u64);
 
         assert_eq!(a.fitness(), 10);
         assert_eq!(b.fitness(), 100);
+        assert_eq!(c.fitness(), Reverse(50));
     }
 }

--- a/packages/brace-ec/src/core/individual.rs
+++ b/packages/brace-ec/src/core/individual.rs
@@ -1,3 +1,5 @@
+use std::cmp::Reverse;
+
 use rand::thread_rng;
 
 use super::operator::mutator::Mutator;
@@ -39,6 +41,21 @@ impl<T> Individual for Vec<T> {
 
     fn genome_mut(&mut self) -> &mut Self::Genome {
         self
+    }
+}
+
+impl<T> Individual for Reverse<T>
+where
+    T: Individual,
+{
+    type Genome = T::Genome;
+
+    fn genome(&self) -> &Self::Genome {
+        self.0.genome()
+    }
+
+    fn genome_mut(&mut self) -> &mut Self::Genome {
+        self.0.genome_mut()
     }
 }
 


### PR DESCRIPTION
This implements `Individual` and `Fitness` for `std::cmp::Reverse`.

The standard library provides the `Reverse` adapter type to reverse the ordering. This is intended to be used in methods such as `Vec::sort_by_key` but it is useful here to reverse the fitness which must implement `Ord`.

This change implements `Individual` for `Reverse` by delegating to the inner individual, and implements `Fitness` for `Reverse` by wrapping the inner individual's fitness. This should ensure that future selectors can use either the lowest or highest fitness individuals depending on whether the wrapper type is used or not.