### PR TITLE
Add `Scored` individual

### DIFF
--- a/packages/brace-ec/src/core/individual/mod.rs
+++ b/packages/brace-ec/src/core/individual/mod.rs
@@ -1,3 +1,5 @@
+pub mod scored;
+
 use std::cmp::Reverse;
 
 use rand::thread_rng;

--- a/packages/brace-ec/src/core/individual/scored.rs
+++ b/packages/brace-ec/src/core/individual/scored.rs
@@ -1,0 +1,72 @@
+use crate::core::fitness::Fitness;
+
+use super::Individual;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Scored<T, S> {
+    pub individual: T,
+    pub score: S,
+}
+
+impl<T, S> Scored<T, S> {
+    pub fn new(individual: T, score: S) -> Self {
+        Self { individual, score }
+    }
+}
+
+impl<T, S> Individual for Scored<T, S>
+where
+    T: Individual,
+{
+    type Genome = T::Genome;
+
+    fn genome(&self) -> &Self::Genome {
+        self.individual.genome()
+    }
+
+    fn genome_mut(&mut self) -> &mut Self::Genome {
+        self.individual.genome_mut()
+    }
+}
+
+impl<T, S> Fitness for Scored<T, S>
+where
+    T: Individual,
+    S: Ord + Clone,
+{
+    type Value = S;
+
+    fn fitness(&self) -> Self::Value {
+        self.score.clone()
+    }
+}
+
+impl<T, S> From<T> for Scored<T, S>
+where
+    S: Default,
+{
+    fn from(individual: T) -> Self {
+        Self::new(individual, S::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::fitness::Fitness;
+    use crate::core::individual::Individual;
+
+    use super::Scored;
+
+    #[test]
+    fn test_individual() {
+        let mut individual = Scored::<_, i32>::from([1, 0]);
+
+        assert_eq!(individual.genome(), [1, 0]);
+        assert_eq!(individual.fitness(), 0);
+
+        individual.score = 10;
+
+        assert_eq!(individual.genome(), [1, 0]);
+        assert_eq!(individual.fitness(), 10);
+    }
+}


### PR DESCRIPTION
This adds a new `Scored` individual using the score as the fitness value.

The `Fitness` trait is currently implemented on primitive scalars and adapters using the individual as the fitness. However, it is also necessary to support individuals where the fitness value is separate.

This change introduces a new `Scored` type containing an individual and a score. This implements both the `Individual` and `Fitness` traits as well as a number of derives and a `From` conversion for an unscored individual. This allows for arbitrary types to be used as the score for any individual, including integers and floats. This does not yet provide a way to set or use the score in a generic way.