### PR TITLE
Add `Scorer` operator trait

### DIFF
--- a/packages/brace-ec/src/core/operator/mod.rs
+++ b/packages/brace-ec/src/core/operator/mod.rs
@@ -3,4 +3,5 @@ pub mod inspect;
 pub mod mutator;
 pub mod recombinator;
 pub mod repeat;
+pub mod scorer;
 pub mod selector;

--- a/packages/brace-ec/src/core/operator/scorer/mod.rs
+++ b/packages/brace-ec/src/core/operator/scorer/mod.rs
@@ -1,0 +1,9 @@
+use crate::core::individual::Individual;
+
+pub trait Scorer {
+    type Individual: Individual;
+    type Score: Ord;
+    type Error;
+
+    fn score(&self, individual: &Self::Individual) -> Result<Self::Score, Self::Error>;
+}


### PR DESCRIPTION
This adds a new `Scorer` operator trait for calculating individual scores.

The `Scored` individual type was added in #33 as a way to store a fitness score that is separate to the individual genome, but there is not yet a way to calculate and store the score in the operator pipeline.

This change simply adds a new `Scorer` operator that takes a reference to an individual and returns a new score. It does not store the score so that should be left up to another operator. There are no tests because there are no implementations of the trait but those will be added shortly.