### PR TITLE
Add `Function` scorer

### DIFF
--- a/packages/brace-ec/src/core/operator/scorer/function.rs
+++ b/packages/brace-ec/src/core/operator/scorer/function.rs
@@ -1,0 +1,58 @@
+use std::marker::PhantomData;
+
+use crate::core::individual::Individual;
+
+use super::Scorer;
+
+pub struct Function<F, I> {
+    scorer: F,
+    marker: PhantomData<fn() -> I>,
+}
+
+impl<F, I> Function<F, I> {
+    pub fn new(scorer: F) -> Self {
+        Self {
+            scorer,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<F, I, S, E> Scorer for Function<F, I>
+where
+    F: Fn(&I) -> Result<S, E>,
+    I: Individual,
+    S: Ord,
+{
+    type Individual = I;
+    type Score = S;
+    type Error = E;
+
+    fn score(&self, individual: &Self::Individual) -> Result<Self::Score, Self::Error> {
+        (self.scorer)(individual)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+
+    use crate::core::operator::scorer::Scorer;
+
+    use super::Function;
+
+    fn sum([a, b]: &[i32; 2]) -> Result<i32, Infallible> {
+        Ok(a + b)
+    }
+
+    #[test]
+    fn test_score() {
+        let individual = [10, 20];
+
+        let a = Function::new(|[a, b]: &[i32; 2]| Ok::<_, Infallible>(a + b));
+        let b = Function::new(sum);
+
+        assert_eq!(a.score(&individual).unwrap(), 30);
+        assert_eq!(b.score(&individual).unwrap(), 30);
+    }
+}

--- a/packages/brace-ec/src/core/operator/scorer/mod.rs
+++ b/packages/brace-ec/src/core/operator/scorer/mod.rs
@@ -1,3 +1,5 @@
+pub mod function;
+
 use crate::core::individual::Individual;
 
 pub trait Scorer {


### PR DESCRIPTION
This adds a new `Function` scorer that supports using a function or closure to score an individual.

The `Scorer` trait was added in #34 with no implementations. However, it would be useful to allow functions and closures to be used as scorers. Unfortunately, the design of the trait makes this awkward.

This change introduces a new `Function` type that stores a function or closure and calls it to score an individual. The usage of a closure is awkward as it requires the user to specify the types instead of them being inferred from usage.

The design of the trait uses an associated individual to match the other operators but this means that a second generic must be added to the new scorer. Scoring is unlikely to need to be composed so this may be something that can be changed in the future. Had the individual been a generic instead of an associated type then the scorer could have been implemented on the closure itself rather than needing this wrapper type.