### PR TITLE
Add `FitnessMut` trait

### DIFF
--- a/packages/brace-ec/src/core/fitness.rs
+++ b/packages/brace-ec/src/core/fitness.rs
@@ -52,6 +52,18 @@ macro_rules! impl_fitness {
 impl_fitness!(u8, u16, u32, u64, u128, usize);
 impl_fitness!(i8, i16, i32, i64, i128, isize);
 
+pub trait FitnessMut: Fitness {
+    fn set_fitness(&mut self, fitness: Self::Value);
+
+    fn with_fitness(mut self, fitness: Self::Value) -> Self
+    where
+        Self: Sized,
+    {
+        self.set_fitness(fitness);
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::cmp::Reverse;

--- a/packages/brace-ec/src/core/individual/scored.rs
+++ b/packages/brace-ec/src/core/individual/scored.rs
@@ -1,4 +1,4 @@
-use crate::core::fitness::Fitness;
+use crate::core::fitness::{Fitness, FitnessMut};
 
 use super::Individual;
 
@@ -38,6 +38,16 @@ where
 
     fn fitness(&self) -> Self::Value {
         self.score.clone()
+    }
+}
+
+impl<T, S> FitnessMut for Scored<T, S>
+where
+    T: Individual,
+    S: Ord + Clone,
+{
+    fn set_fitness(&mut self, fitness: Self::Value) {
+        self.score = fitness;
     }
 }
 


### PR DESCRIPTION
This adds a new `FitnessMut` trait to complement the existing `Fitness` trait.

The current implementation of the `Fitness` trait provides immutable access to the fitness of an individual. This is suitable for the various primitive types where the fitness is the individual itself but it is not enough for something like the `Scored` individual where the fitness is a separate value. It would have been possible to add separate mutation methods to the existing trait but that would allow scoring to become a mutator and potentially invalidate the logic.

This change simply introduces a new `FitnessMut` trait that extends the existing `Fitness` trait to provide the `set_fitness` and `with_fitness` methods. It also implements this for the `Scored` individual to ensure that only individuals with a separate fitness can be updated.