### PR TITLE
Add `Generation::population_mut` method

### DIFF
--- a/packages/brace-ec/src/core/generation.rs
+++ b/packages/brace-ec/src/core/generation.rs
@@ -7,6 +7,8 @@ pub trait Generation {
     fn id(&self) -> &Self::Id;
 
     fn population(&self) -> &Self::Population;
+
+    fn population_mut(&mut self) -> &mut Self::Population;
 }
 
 impl<T, P> Generation for (T, P)
@@ -22,6 +24,10 @@ where
 
     fn population(&self) -> &Self::Population {
         &self.1
+    }
+
+    fn population_mut(&mut self) -> &mut Self::Population {
+        &mut self.1
     }
 }
 


### PR DESCRIPTION
This simply adds a new `Generation::population_mut` method.

The `Generation` trait already provides a `population` method but it does not offer a way to mutate the population in any way. The `Individual` trait exposes both `genome` and `genome_mut` methods and `Chromosome` exposes the `gene` and `gene_mut` methods. Therefore the generation should support a `population_mut` method for consistency.

This change adds a new `population_mut` method to `Generation` and implements it for the tuple generation type.