### PR TITLE
Add `IterableMut` helper trait

### DIFF
--- a/packages/brace-ec/src/util/iter.rs
+++ b/packages/brace-ec/src/util/iter.rs
@@ -46,3 +46,44 @@ impl<T> Iterable for Option<T> {
         self.iter()
     }
 }
+
+pub trait IterableMut: Iterable {
+    type IterMut<'a>: Iterator<Item = &'a mut Self::Item>
+    where
+        Self: 'a;
+
+    fn iter_mut(&mut self) -> Self::IterMut<'_>;
+}
+
+impl<const N: usize, T> IterableMut for [T; N] {
+    type IterMut<'a>
+        = std::slice::IterMut<'a, T>
+    where
+        T: 'a;
+
+    fn iter_mut(&mut self) -> Self::IterMut<'_> {
+        self.as_mut_slice().iter_mut()
+    }
+}
+
+impl<T> IterableMut for Vec<T> {
+    type IterMut<'a>
+        = std::slice::IterMut<'a, T>
+    where
+        T: 'a;
+
+    fn iter_mut(&mut self) -> Self::IterMut<'_> {
+        (**self).iter_mut()
+    }
+}
+
+impl<T> IterableMut for Option<T> {
+    type IterMut<'a>
+        = std::option::IterMut<'a, T>
+    where
+        Self: 'a;
+
+    fn iter_mut(&mut self) -> Self::IterMut<'_> {
+        self.iter_mut()
+    }
+}


### PR DESCRIPTION
This adds a new `IterableMut` helper trait.

The `Iterable` trait was introduced in #2 along with the `IterablePopulation` trait and made it simple to iterate over a population. However, upcoming operators also need to iterate over a mutable population and this needs another trait.

This simply adds a new `IterableMut` trait that extends `Iterable` and is implemented on the same collection types. This uses a separate trait because in the future it may be necessary to allow for "view" populations that return a view or subset of another population. In this case those types would store a reference to the original population and it would not be possible to iterate over mutable values.