### PR TITLE
Add `Score` operator adapter

### DIFF
--- a/packages/brace-ec/src/core/operator/evolver/mod.rs
+++ b/packages/brace-ec/src/core/operator/evolver/mod.rs
@@ -1,15 +1,31 @@
 pub mod select;
 
+use crate::core::fitness::{Fitness, FitnessMut};
 use crate::core::generation::Generation;
+use crate::core::population::Population;
 
 use super::inspect::Inspect;
 use super::repeat::Repeat;
+use super::score::Score;
+use super::scorer::Scorer;
 
 pub trait Evolver {
     type Generation: Generation;
     type Error;
 
     fn evolve(&self, generation: Self::Generation) -> Result<Self::Generation, Self::Error>;
+
+    fn score<S>(self, scorer: S) -> Score<Self, S>
+    where
+        S: Scorer<
+            Individual = <<Self::Generation as Generation>::Population as Population>::Individual,
+            Score = <<<Self::Generation as Generation>::Population as Population>::Individual as Fitness>::Value,
+        >,
+        <<Self::Generation as Generation>::Population as Population>::Individual: FitnessMut,
+        Self: Sized,
+    {
+        Score::new(self, scorer)
+    }
 
     fn repeat(self, count: usize) -> Repeat<Self>
     where

--- a/packages/brace-ec/src/core/operator/mod.rs
+++ b/packages/brace-ec/src/core/operator/mod.rs
@@ -3,5 +3,6 @@ pub mod inspect;
 pub mod mutator;
 pub mod recombinator;
 pub mod repeat;
+pub mod score;
 pub mod scorer;
 pub mod selector;

--- a/packages/brace-ec/src/core/operator/mutator/mod.rs
+++ b/packages/brace-ec/src/core/operator/mutator/mod.rs
@@ -4,12 +4,15 @@ pub mod rate;
 
 use rand::Rng;
 
+use crate::core::fitness::{Fitness, FitnessMut};
 use crate::core::individual::Individual;
 
 use self::rate::Rate;
 
 use super::inspect::Inspect;
 use super::repeat::Repeat;
+use super::score::Score;
+use super::scorer::Scorer;
 
 pub trait Mutator: Sized {
     type Individual: Individual;
@@ -22,6 +25,14 @@ pub trait Mutator: Sized {
     ) -> Result<Self::Individual, Self::Error>
     where
         R: Rng + ?Sized;
+
+    fn score<S>(self, scorer: S) -> Score<Self, S>
+    where
+        S: Scorer<Individual = Self::Individual, Score = <Self::Individual as Fitness>::Value>,
+        Self::Individual: FitnessMut,
+    {
+        Score::new(self, scorer)
+    }
 
     fn rate(self, rate: f64) -> Rate<Self>
     where

--- a/packages/brace-ec/src/core/operator/recombinator/mod.rs
+++ b/packages/brace-ec/src/core/operator/recombinator/mod.rs
@@ -2,10 +2,13 @@ pub mod sum;
 
 use rand::Rng;
 
+use crate::core::fitness::{Fitness, FitnessMut};
 use crate::core::population::Population;
 
 use super::inspect::Inspect;
 use super::repeat::Repeat;
+use super::score::Score;
+use super::scorer::Scorer;
 
 pub trait Recombinator {
     type Parents: Population;
@@ -19,6 +22,18 @@ pub trait Recombinator {
     ) -> Result<Self::Output, Self::Error>
     where
         R: Rng + ?Sized;
+
+    fn score<S>(self, scorer: S) -> Score<Self, S>
+    where
+        S: Scorer<
+            Individual = <Self::Parents as Population>::Individual,
+            Score = <<Self::Parents as Population>::Individual as Fitness>::Value,
+        >,
+        <Self::Parents as Population>::Individual: FitnessMut,
+        Self: Sized,
+    {
+        Score::new(self, scorer)
+    }
 
     fn repeat(self, count: usize) -> Repeat<Self>
     where

--- a/packages/brace-ec/src/core/operator/score.rs
+++ b/packages/brace-ec/src/core/operator/score.rs
@@ -1,0 +1,253 @@
+use rand::Rng;
+use thiserror::Error;
+
+use crate::core::fitness::FitnessMut;
+use crate::core::generation::Generation;
+use crate::core::population::Population;
+use crate::util::iter::IterableMut;
+use crate::util::map::TryMap;
+
+use super::evolver::Evolver;
+use super::mutator::Mutator;
+use super::recombinator::Recombinator;
+use super::scorer::Scorer;
+use super::selector::Selector;
+
+pub struct Score<T, S> {
+    operator: T,
+    scorer: S,
+}
+
+impl<T, S> Score<T, S> {
+    pub fn new(operator: T, scorer: S) -> Self {
+        Self { operator, scorer }
+    }
+}
+
+impl<T, S, I> Selector for Score<T, S>
+where
+    T: Selector<Population: Population<Individual = I>, Output: TryMap<Item = I>>,
+    S: Scorer<Individual = I, Score = I::Value>,
+    I: FitnessMut,
+{
+    type Population = T::Population;
+    type Output = T::Output;
+    type Error = ScoreError<T::Error, S::Error>;
+
+    fn select<R>(
+        &self,
+        population: &Self::Population,
+        rng: &mut R,
+    ) -> Result<Self::Output, Self::Error>
+    where
+        R: Rng + ?Sized,
+    {
+        self.operator
+            .select(population, rng)
+            .map_err(ScoreError::Operate)?
+            .try_map(|individual| {
+                let fitness = self.scorer.score(&individual)?;
+
+                Ok(individual.with_fitness(fitness))
+            })
+            .map_err(ScoreError::Score)
+    }
+}
+
+impl<T, S, I> Mutator for Score<T, S>
+where
+    T: Mutator<Individual = I>,
+    S: Scorer<Individual = I, Score = I::Value>,
+    I: FitnessMut,
+{
+    type Individual = T::Individual;
+    type Error = ScoreError<T::Error, S::Error>;
+
+    fn mutate<R>(
+        &self,
+        individual: Self::Individual,
+        rng: &mut R,
+    ) -> Result<Self::Individual, Self::Error>
+    where
+        R: Rng + ?Sized,
+    {
+        let individual = self
+            .operator
+            .mutate(individual, rng)
+            .map_err(ScoreError::Operate)?;
+
+        let fitness = self.scorer.score(&individual).map_err(ScoreError::Score)?;
+
+        Ok(individual.with_fitness(fitness))
+    }
+}
+
+impl<T, S, I> Recombinator for Score<T, S>
+where
+    T: Recombinator<Parents: Population<Individual = I>, Output: TryMap<Item = I>>,
+    S: Scorer<Individual = I, Score = I::Value>,
+    I: FitnessMut,
+{
+    type Parents = T::Parents;
+    type Output = T::Output;
+    type Error = ScoreError<T::Error, S::Error>;
+
+    fn recombine<R>(&self, parents: Self::Parents, rng: &mut R) -> Result<Self::Output, Self::Error>
+    where
+        R: Rng + ?Sized,
+    {
+        self.operator
+            .recombine(parents, rng)
+            .map_err(ScoreError::Operate)?
+            .try_map(|individual| {
+                let fitness = self.scorer.score(&individual)?;
+
+                Ok(individual.with_fitness(fitness))
+            })
+            .map_err(ScoreError::Score)
+    }
+}
+
+impl<T, S, P, I> Evolver for Score<T, S>
+where
+    T: Evolver<Generation: Generation<Population = P>>,
+    S: Scorer<Individual = I, Score = I::Value>,
+    P: Population<Individual = I> + IterableMut<Item = I>,
+    I: FitnessMut,
+{
+    type Generation = T::Generation;
+    type Error = ScoreError<T::Error, S::Error>;
+
+    fn evolve(&self, generation: Self::Generation) -> Result<Self::Generation, Self::Error> {
+        let mut generation = self
+            .operator
+            .evolve(generation)
+            .map_err(ScoreError::Operate)?;
+
+        generation
+            .population_mut()
+            .iter_mut()
+            .try_for_each(|individual| {
+                let fitness = self.scorer.score(individual)?;
+
+                individual.set_fitness(fitness);
+
+                Ok(())
+            })
+            .map_err(ScoreError::Score)?;
+
+        Ok(generation)
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ScoreError<O, S> {
+    #[error(transparent)]
+    Operate(O),
+    #[error(transparent)]
+    Score(S),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+
+    use rand::Rng;
+
+    use crate::core::individual::scored::Scored;
+    use crate::core::individual::Individual;
+    use crate::core::operator::evolver::select::Select;
+    use crate::core::operator::evolver::Evolver;
+    use crate::core::operator::mutator::add::Add;
+    use crate::core::operator::mutator::Mutator;
+    use crate::core::operator::recombinator::Recombinator;
+    use crate::core::operator::scorer::function::Function;
+    use crate::core::operator::selector::first::First;
+    use crate::core::operator::selector::Selector;
+    use crate::core::population::Population;
+
+    fn double(individual: &Scored<i32, i32>) -> Result<i32, Infallible> {
+        Ok(individual.individual * 2)
+    }
+
+    fn triple(individual: &Scored<i32, i32>) -> Result<i32, Infallible> {
+        Ok(individual.individual * 3)
+    }
+
+    struct Noop;
+
+    impl Recombinator for Noop {
+        type Parents = [Scored<i32, i32>; 2];
+        type Output = [Scored<i32, i32>; 2];
+        type Error = Infallible;
+
+        fn recombine<R>(
+            &self,
+            parents: Self::Parents,
+            _: &mut R,
+        ) -> Result<Self::Output, Self::Error>
+        where
+            R: Rng + ?Sized,
+        {
+            Ok(parents)
+        }
+    }
+
+    #[test]
+    fn test_select() {
+        let population = [Scored::new(10, 0)];
+
+        let a = population
+            .select(First.score(Function::new(double)))
+            .unwrap()[0];
+        let b = population
+            .select(First.score(Function::new(triple)))
+            .unwrap()[0];
+
+        assert_eq!(a, Scored::new(10, 20));
+        assert_eq!(b, Scored::new(10, 30));
+    }
+
+    #[test]
+    fn test_mutate() {
+        let a = Scored::new(10, 0)
+            .mutate(Add(5).score(Function::new(double)))
+            .unwrap();
+        let b = Scored::new(10, 0)
+            .mutate(Add(5).score(Function::new(triple)))
+            .unwrap();
+
+        assert_eq!(a, Scored::new(15, 30));
+        assert_eq!(b, Scored::new(15, 45));
+    }
+
+    #[test]
+    fn test_recombine() {
+        let population = [Scored::new(10, 0), Scored::new(20, 0)];
+
+        let a = population
+            .recombine(Noop.score(Function::new(double)))
+            .unwrap();
+        let b = population
+            .recombine(Noop.score(Function::new(triple)))
+            .unwrap();
+
+        assert_eq!(a, [Scored::new(10, 20), Scored::new(20, 40)]);
+        assert_eq!(b, [Scored::new(10, 30), Scored::new(20, 60)]);
+    }
+
+    #[test]
+    fn test_evolve() {
+        let a = Select::new(First)
+            .score(Function::new(double))
+            .evolve((0, [Scored::new(10, 0), Scored::new(20, 0)]))
+            .unwrap();
+        let b = Select::new(First)
+            .score(Function::new(triple))
+            .evolve((0, [Scored::new(10, 0), Scored::new(20, 0)]))
+            .unwrap();
+
+        assert_eq!(a, (1, [Scored::new(10, 20), Scored::new(10, 20)]));
+        assert_eq!(b, (1, [Scored::new(10, 30), Scored::new(10, 30)]));
+    }
+}

--- a/packages/brace-ec/src/core/operator/selector/mod.rs
+++ b/packages/brace-ec/src/core/operator/selector/mod.rs
@@ -5,6 +5,7 @@ pub mod recombine;
 
 use rand::Rng;
 
+use crate::core::fitness::{Fitness, FitnessMut};
 use crate::core::population::Population;
 
 use self::mutate::Mutate;
@@ -14,6 +15,8 @@ use super::inspect::Inspect;
 use super::mutator::Mutator;
 use super::recombinator::Recombinator;
 use super::repeat::Repeat;
+use super::score::Score;
+use super::scorer::Scorer;
 
 pub trait Selector: Sized {
     type Population: Population;
@@ -40,6 +43,17 @@ pub trait Selector: Sized {
         R: Recombinator<Parents = Self::Output>,
     {
         Recombine::new(self, recombinator)
+    }
+
+    fn score<S>(self, scorer: S) -> Score<Self, S>
+    where
+        S: Scorer<
+            Individual = <Self::Population as Population>::Individual,
+            Score = <<Self::Population as Population>::Individual as Fitness>::Value,
+        >,
+        <Self::Population as Population>::Individual: FitnessMut,
+    {
+        Score::new(self, scorer)
     }
 
     fn repeat(self, count: usize) -> Repeat<Self>


### PR DESCRIPTION
This adds a new `Score` operator adapter that supports the `Selector`, `Mutator`, `Recombinator` and `Evolver` traits.

The process of scoring individuals should be incorporated into the operator pipeline such that operators can be scored at the appropriate time. This could be after selection or after evolution depending on the requirements of the system.

This change introduces a new `Score` operator adapter that composes each of the main operators with a scorer. It also includes helper methods on the `Selector`, `Mutator`, `Recombinator` and `Evolver` traits to simplify composition and chaining.

The implementation of this type may be overkill as it only really needed to support scoring during selection and not after other operators. Then a separate scoring evolver could have been introduced that has access to the entire population as context to score individuals. However, this implementation allows for some interesting scenarios. For example, a mutator that keeps mutating until the score reaches a certain threshold or a recombinator that recombines the best individuals.

The trait methods are rather complex and could be simplified by introducing further generics but it is unclear whether this would have impacted the type inference. They also do not implement the full bounds and omit the `IterableMut` and `TryMap` requirements but the type system should flag that if they are not met. The types could have been omitted entirely but the purpose was to ensure that the inputs and outputs aligned for type inference.