### PR TITLE
Add `Best` selector

### DIFF
--- a/packages/brace-ec/src/core/operator/selector/best.rs
+++ b/packages/brace-ec/src/core/operator/selector/best.rs
@@ -1,0 +1,74 @@
+use rand::Rng;
+use thiserror::Error;
+
+use crate::core::fitness::Fitness;
+use crate::core::population::{IterablePopulation, Population};
+
+use super::Selector;
+
+#[ghost::phantom]
+#[derive(Clone, Copy, Debug)]
+pub struct Best<P: Population>;
+
+impl<P> Selector for Best<P>
+where
+    P: IterablePopulation<Individual: Clone + Fitness>,
+{
+    type Population = P;
+    type Output = [P::Individual; 1];
+    type Error = BestError;
+
+    fn select<R>(&self, population: &P, _: &mut R) -> Result<Self::Output, Self::Error>
+    where
+        R: Rng + ?Sized,
+    {
+        Ok([population
+            .iter()
+            .max_by_key(|individual| individual.fitness())
+            .ok_or(BestError::Empty)?
+            .clone()])
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum BestError {
+    #[error("empty population")]
+    Empty,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cmp::Reverse;
+
+    use crate::core::individual::scored::Scored;
+    use crate::core::population::Population;
+
+    use super::Best;
+
+    #[test]
+    fn test_select() {
+        let population = [0, 1, 2, 3, 4];
+        let individual = population.select(Best).unwrap()[0];
+
+        assert_eq!(individual, 4);
+
+        let population = [Reverse(0), Reverse(1), Reverse(2), Reverse(3), Reverse(4)];
+        let individual = population.select(Best).unwrap()[0];
+
+        assert_eq!(individual, Reverse(0));
+
+        let population = [Scored::new(0, 0), Scored::new(10, 10), Scored::new(20, 5)];
+        let individual = population.select(Best).unwrap()[0];
+
+        assert_eq!(individual, Scored::new(10, 10));
+
+        let population = [
+            Reverse(Scored::new(30, 3)),
+            Reverse(Scored::new(10, 10)),
+            Reverse(Scored::new(20, 5)),
+        ];
+        let individual = population.select(Best).unwrap()[0];
+
+        assert_eq!(individual, Reverse(Scored::new(30, 3)));
+    }
+}

--- a/packages/brace-ec/src/core/operator/selector/mod.rs
+++ b/packages/brace-ec/src/core/operator/selector/mod.rs
@@ -1,3 +1,4 @@
+pub mod best;
 pub mod first;
 pub mod mutate;
 pub mod random;


### PR DESCRIPTION
This adds a new `Best` selector for selecting the individual with the best fitness.

There are not yet any selectors that use the fitness to select an individual. In evolutionary computation it is often desired to get the best individual from the population.

This change simply introduces a new `Best` selector that selects the best individual from the population using the `Fitness` trait. The tests cover various scenarios using the selector and simple adapters including `Reverse` and `Scored`. The default is to use the largest fitness but there are some systems that want the smallest so this should be documented at a later date.