### PR TITLE
Add `Tournament` selector

### DIFF
--- a/packages/brace-ec/src/core/operator/selector/mod.rs
+++ b/packages/brace-ec/src/core/operator/selector/mod.rs
@@ -3,6 +3,7 @@ pub mod first;
 pub mod mutate;
 pub mod random;
 pub mod recombine;
+pub mod tournament;
 
 use rand::Rng;
 


### PR DESCRIPTION
This adds a new `Tournament` selector that selects a number of individuals at random and chooses the best.

Evolutionary computation commonly uses tournament selection as it allows the algorithm to select the best individual from a subset of individuals as specified by the tournament size. A tournament where the size is 1 is equivalent to random selection and a tournament where the size is equal to the number of individuals is equivalent to selecting the best individual.

This change introduces a new `Tournament` selector that takes an iterable population of individuals with a fitness, selects a subset of those individuals according to the tournament size, and then chooses the best of that subset.