### PR TITLE
Add `Noise` mutator

### DIFF
--- a/packages/brace-ec/src/core/operator/mutator/mod.rs
+++ b/packages/brace-ec/src/core/operator/mutator/mod.rs
@@ -1,5 +1,6 @@
 pub mod add;
 pub mod invert;
+pub mod noise;
 pub mod rate;
 
 use rand::Rng;

--- a/packages/brace-ec/src/core/operator/mutator/noise.rs
+++ b/packages/brace-ec/src/core/operator/mutator/noise.rs
@@ -1,0 +1,100 @@
+use std::convert::Infallible;
+use std::ops::{Add, Range, RangeBounds};
+
+use num_traits::{Bounded, One, SaturatingAdd, SaturatingSub};
+use rand::distributions::uniform::SampleUniform;
+use rand::Rng;
+
+use crate::core::individual::Individual;
+use crate::util::range::get_range;
+
+use super::Mutator;
+
+#[derive(Clone, Debug)]
+pub struct Noise<T>(pub Range<T::Genome>)
+where
+    T: Individual<Genome: Sized>;
+
+impl<T> Noise<T>
+where
+    T: Individual,
+    T::Genome: PartialOrd + Clone + One + Bounded + Add<Output = T::Genome> + Sized,
+{
+    pub fn new<R>(range: R) -> Self
+    where
+        R: RangeBounds<T::Genome>,
+    {
+        Self(get_range(range))
+    }
+}
+
+impl<T> Mutator for Noise<T>
+where
+    T: Individual,
+    T::Genome: Clone + PartialOrd + SaturatingAdd + SaturatingSub + SampleUniform,
+{
+    type Individual = T;
+    type Error = Infallible;
+
+    fn mutate<R>(
+        &self,
+        mut individual: Self::Individual,
+        rng: &mut R,
+    ) -> Result<Self::Individual, Self::Error>
+    where
+        R: Rng + ?Sized,
+    {
+        let genome = match rng.gen_bool(0.5) {
+            true => individual
+                .genome()
+                .saturating_add(&rng.gen_range(self.0.clone())),
+            false => individual
+                .genome()
+                .saturating_sub(&rng.gen_range(self.0.clone())),
+        };
+
+        *individual.genome_mut() = genome;
+
+        Ok(individual)
+    }
+}
+
+impl<T> Default for Noise<T>
+where
+    T: Individual,
+    T::Genome: PartialOrd + Clone + One + Bounded + Add<Output = T::Genome> + Sized,
+{
+    fn default() -> Self {
+        Self::new(T::Genome::one()..=T::Genome::one())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::individual::Individual;
+
+    use super::Noise;
+
+    #[test]
+    fn test_mutate() {
+        for _ in 0..1_000 {
+            let a = 150.mutate(Noise(1..11)).unwrap();
+
+            assert!(a != 150);
+            assert!(a <= 160);
+            assert!(a >= 140);
+
+            let b = 250.mutate(Noise::new(1..=10)).unwrap();
+
+            assert!(b != 250);
+            assert!(b <= 260);
+            assert!(b >= 240);
+        }
+
+        for _ in 0..10 {
+            let c = 350.mutate(Noise::default()).unwrap();
+
+            assert!(c == 349 || c == 351);
+        }
+    }
+}

--- a/packages/brace-ec/src/util/range.rs
+++ b/packages/brace-ec/src/util/range.rs
@@ -1,4 +1,26 @@
-use std::ops::{Bound, Range, RangeBounds};
+use std::ops::{Add, Bound, Range, RangeBounds};
+
+use num_traits::{Bounded, One};
+
+pub fn get_range<R, T>(range: R) -> Range<T>
+where
+    R: RangeBounds<T>,
+    T: PartialOrd + Clone + One + Bounded + Add<Output = T>,
+{
+    let start = match range.start_bound() {
+        Bound::Included(start) => start.clone(),
+        Bound::Excluded(start) => start.clone() + T::one(),
+        Bound::Unbounded => T::min_value(),
+    };
+
+    let end = match range.end_bound() {
+        Bound::Included(end) => end.clone() + T::one(),
+        Bound::Excluded(end) => end.clone(),
+        Bound::Unbounded => T::max_value(),
+    };
+
+    start..end
+}
 
 pub fn get_range_to<R>(range: R, max: usize) -> Range<usize>
 where


### PR DESCRIPTION
This adds a `Noise` mutator that adds or subtracts noise to a value in the given range.

The `Add` type is a simple example of a mutator that adds a fixed value to the individual genome. Together with the `Repeat` and `Rate` adapters it can be turned into something more complex that works like applying noise. However, a separate noise mutator would be more useful to create this effect and support subtraction.

This change introduces a new `Noise` mutator that randomly adds or subtracts a random value in the specified range. This includes a constructor that utilises a new `get_range` helper method to support the various types of range provided by the standard library. An unbounded range will use a random value between the minimum and maximum values.

The mutator will always mutate the value with a 50% chance of addition and 50% chance of subtraction. To limit this the user can set the range to include the zero value or apply the `Rate` adapter to reduce the frequency of the mutation.

The implementation uses both the `SaturatingAdd` and `SaturatingSub` traits so that whatever the range it will either add or subtract. Using a range that spans from negative to positive is supported but may produce interesting results.

The implementation will panic on an empty range so it may be beneficial to add a runtime check and return an error.