### PR TITLE
Add `Then` operator adapter

### DIFF
--- a/packages/brace-ec/src/core/operator/evolver/mod.rs
+++ b/packages/brace-ec/src/core/operator/evolver/mod.rs
@@ -8,6 +8,7 @@ use super::inspect::Inspect;
 use super::repeat::Repeat;
 use super::score::Score;
 use super::scorer::Scorer;
+use super::then::Then;
 
 pub trait Evolver {
     type Generation: Generation;
@@ -25,6 +26,14 @@ pub trait Evolver {
         Self: Sized,
     {
         Score::new(self, scorer)
+    }
+
+    fn then<E>(self, evolver: E) -> Then<Self, E>
+    where
+        E: Evolver<Generation = Self::Generation>,
+        Self: Sized,
+    {
+        Then::new(self, evolver)
     }
 
     fn repeat(self, count: usize) -> Repeat<Self>

--- a/packages/brace-ec/src/core/operator/mod.rs
+++ b/packages/brace-ec/src/core/operator/mod.rs
@@ -6,3 +6,4 @@ pub mod repeat;
 pub mod score;
 pub mod scorer;
 pub mod selector;
+pub mod then;

--- a/packages/brace-ec/src/core/operator/mutator/mod.rs
+++ b/packages/brace-ec/src/core/operator/mutator/mod.rs
@@ -14,6 +14,7 @@ use super::inspect::Inspect;
 use super::repeat::Repeat;
 use super::score::Score;
 use super::scorer::Scorer;
+use super::then::Then;
 
 pub trait Mutator: Sized {
     type Individual: Individual;
@@ -33,6 +34,13 @@ pub trait Mutator: Sized {
         Self::Individual: FitnessMut,
     {
         Score::new(self, scorer)
+    }
+
+    fn then<M>(self, mutator: M) -> Then<Self, M>
+    where
+        M: Mutator<Individual = Self::Individual>,
+    {
+        Then::new(self, mutator)
     }
 
     fn rate(self, rate: f64) -> Rate<Self>

--- a/packages/brace-ec/src/core/operator/recombinator/mod.rs
+++ b/packages/brace-ec/src/core/operator/recombinator/mod.rs
@@ -9,6 +9,7 @@ use super::inspect::Inspect;
 use super::repeat::Repeat;
 use super::score::Score;
 use super::scorer::Scorer;
+use super::then::Then;
 
 pub trait Recombinator {
     type Parents: Population;
@@ -33,6 +34,14 @@ pub trait Recombinator {
         Self: Sized,
     {
         Score::new(self, scorer)
+    }
+
+    fn then<R>(self, recombinator: R) -> Then<Self, R>
+    where
+        R: Recombinator<Parents = Self::Output>,
+        Self: Sized,
+    {
+        Then::new(self, recombinator)
     }
 
     fn repeat(self, count: usize) -> Repeat<Self>

--- a/packages/brace-ec/src/core/operator/selector/mod.rs
+++ b/packages/brace-ec/src/core/operator/selector/mod.rs
@@ -19,6 +19,7 @@ use super::recombinator::Recombinator;
 use super::repeat::Repeat;
 use super::score::Score;
 use super::scorer::Scorer;
+use super::then::Then;
 
 pub trait Selector: Sized {
     type Population: Population;
@@ -56,6 +57,13 @@ pub trait Selector: Sized {
         <Self::Population as Population>::Individual: FitnessMut,
     {
         Score::new(self, scorer)
+    }
+
+    fn then<S>(self, selector: S) -> Then<Self, S>
+    where
+        S: Selector<Population = Self::Output>,
+    {
+        Then::new(self, selector)
     }
 
     fn repeat(self, count: usize) -> Repeat<Self>

--- a/packages/brace-ec/src/core/operator/then.rs
+++ b/packages/brace-ec/src/core/operator/then.rs
@@ -1,0 +1,217 @@
+use rand::Rng;
+use thiserror::Error;
+
+use super::evolver::Evolver;
+use super::mutator::Mutator;
+use super::recombinator::Recombinator;
+use super::selector::Selector;
+
+pub struct Then<L, R> {
+    lhs: L,
+    rhs: R,
+}
+
+impl<L, R> Then<L, R> {
+    pub fn new(lhs: L, rhs: R) -> Self {
+        Self { lhs, rhs }
+    }
+}
+
+impl<L, R> Selector for Then<L, R>
+where
+    L: Selector,
+    R: Selector<Population = L::Output>,
+{
+    type Population = L::Population;
+    type Output = R::Output;
+    type Error = ThenError<L::Error, R::Error>;
+
+    fn select<G>(
+        &self,
+        population: &Self::Population,
+        rng: &mut G,
+    ) -> Result<Self::Output, Self::Error>
+    where
+        G: Rng + ?Sized,
+    {
+        let population = self.lhs.select(population, rng).map_err(ThenError::Left)?;
+
+        self.rhs.select(&population, rng).map_err(ThenError::Right)
+    }
+}
+
+impl<L, R> Mutator for Then<L, R>
+where
+    L: Mutator,
+    R: Mutator<Individual = L::Individual>,
+{
+    type Individual = L::Individual;
+    type Error = ThenError<L::Error, R::Error>;
+
+    fn mutate<G>(
+        &self,
+        individual: Self::Individual,
+        rng: &mut G,
+    ) -> Result<Self::Individual, Self::Error>
+    where
+        G: Rng + ?Sized,
+    {
+        self.rhs
+            .mutate(
+                self.lhs.mutate(individual, rng).map_err(ThenError::Left)?,
+                rng,
+            )
+            .map_err(ThenError::Right)
+    }
+}
+
+impl<L, R> Recombinator for Then<L, R>
+where
+    L: Recombinator,
+    R: Recombinator<Parents = L::Output>,
+{
+    type Parents = L::Parents;
+    type Output = R::Output;
+    type Error = ThenError<L::Error, R::Error>;
+
+    fn recombine<G>(&self, parents: Self::Parents, rng: &mut G) -> Result<Self::Output, Self::Error>
+    where
+        G: Rng + ?Sized,
+    {
+        // Note: Using this form because rust-analyzer gets confused.
+        Recombinator::recombine(
+            &self.rhs,
+            Recombinator::recombine(&self.lhs, parents, rng).map_err(ThenError::Left)?,
+            rng,
+        )
+        .map_err(ThenError::Right)
+    }
+}
+
+impl<L, R> Evolver for Then<L, R>
+where
+    L: Evolver,
+    R: Evolver<Generation = L::Generation>,
+{
+    type Generation = L::Generation;
+    type Error = ThenError<L::Error, R::Error>;
+
+    fn evolve(&self, generation: Self::Generation) -> Result<Self::Generation, Self::Error> {
+        self.rhs
+            .evolve(self.lhs.evolve(generation).map_err(ThenError::Left)?)
+            .map_err(ThenError::Right)
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ThenError<L, R> {
+    #[error(transparent)]
+    Left(L),
+    #[error(transparent)]
+    Right(R),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+
+    use rand::Rng;
+
+    use crate::core::individual::Individual;
+    use crate::core::operator::evolver::select::Select;
+    use crate::core::operator::evolver::Evolver;
+    use crate::core::operator::mutator::add::Add;
+    use crate::core::operator::mutator::Mutator;
+    use crate::core::operator::recombinator::Recombinator;
+    use crate::core::operator::selector::best::Best;
+    use crate::core::operator::selector::first::First;
+    use crate::core::operator::selector::Selector;
+    use crate::core::population::Population;
+
+    struct All;
+
+    impl Selector for All {
+        type Population = [i32; 5];
+        type Output = [i32; 5];
+        type Error = Infallible;
+
+        fn select<R>(
+            &self,
+            population: &Self::Population,
+            _: &mut R,
+        ) -> Result<Self::Output, Self::Error>
+        where
+            R: Rng + ?Sized,
+        {
+            Ok(*population)
+        }
+    }
+
+    struct Swap;
+
+    impl Recombinator for Swap {
+        type Parents = [u8; 2];
+        type Output = [u8; 2];
+        type Error = Infallible;
+
+        fn recombine<R>(
+            &self,
+            parents: Self::Parents,
+            _: &mut R,
+        ) -> Result<Self::Output, Self::Error>
+        where
+            R: Rng + ?Sized,
+        {
+            Ok([parents[1], parents[0]])
+        }
+    }
+
+    #[test]
+    fn test_select() {
+        let population = [0, 1, 2, 3, 4];
+
+        let a = population.select(All.then(Best)).unwrap();
+        let b = population.select(All.then(First)).unwrap();
+
+        assert_eq!(a, [4]);
+        assert_eq!(b, [0]);
+    }
+
+    #[test]
+    fn test_mutate() {
+        let a = 0.mutate(Add(1).then(Add(2))).unwrap();
+        let b = 1.mutate(Add(2).then(Add(1))).unwrap();
+
+        assert_eq!(a, 3);
+        assert_eq!(b, 4);
+    }
+
+    #[test]
+    fn test_recombine() {
+        let population = [0, 1];
+
+        let a = population.recombine(Swap).unwrap();
+        let b = population.recombine(Swap.then(Swap)).unwrap();
+        let c = population.recombine(Swap.then(Swap).then(Swap)).unwrap();
+
+        assert_eq!(a, [1, 0]);
+        assert_eq!(b, [0, 1]);
+        assert_eq!(c, [1, 0]);
+    }
+
+    #[test]
+    fn test_evolve() {
+        let a = Select::new(Best)
+            .then(Select::new(First))
+            .evolve((0, [0, 1, 2, 3, 4]))
+            .unwrap();
+
+        let b = Select::new(First)
+            .then(Select::new(Best))
+            .evolve((0, [0, 1, 2, 3, 4]))
+            .unwrap();
+
+        assert_eq!(a, (2, [4, 4, 4, 4, 4]));
+        assert_eq!(b, (2, [0, 0, 0, 0, 0]));
+    }
+}


### PR DESCRIPTION
This adds a new `Then` operator adapter that allows another operator of the same type to be chained.

The operator system provides adapters such as `Mutate` and `Recombine` for selectors that allow them to be composed with an operator of another type to produce a new operator of the same type. For example, calling `selector.mutate(mutator)` creates a new selector where each selected individual is mutated. However, there is not yet a way to compose selectors of the same type.

This change introduces the `Then` operator adapter that implements `Selector`, `Mutator`, `Recombinator`, and `Evolver` by composing two other operators of the same trait. This includes helper methods on the traits to simplify construction and chaining of the new operator.