### PR TITLE
Add `And` selector adapter

### DIFF
--- a/packages/brace-ec/src/core/operator/selector/and.rs
+++ b/packages/brace-ec/src/core/operator/selector/and.rs
@@ -1,0 +1,74 @@
+use rand::Rng;
+use thiserror::Error;
+
+use crate::core::population::Population;
+
+use super::Selector;
+
+pub struct And<L, R> {
+    lhs: L,
+    rhs: R,
+}
+
+impl<L, R> And<L, R> {
+    pub fn new(lhs: L, rhs: R) -> Self {
+        Self { lhs, rhs }
+    }
+}
+
+impl<L, R> Selector for And<L, R>
+where
+    L: Selector<Output: IntoIterator<Item = <L::Population as Population>::Individual>>,
+    R: Selector<
+        Population = L::Population,
+        Output: IntoIterator<Item = <L::Population as Population>::Individual>,
+    >,
+{
+    type Population = L::Population;
+    type Output = Vec<<L::Population as Population>::Individual>;
+    type Error = AndError<L::Error, R::Error>;
+
+    fn select<G>(
+        &self,
+        population: &Self::Population,
+        rng: &mut G,
+    ) -> Result<Self::Output, Self::Error>
+    where
+        G: Rng + ?Sized,
+    {
+        Ok(self
+            .lhs
+            .select(population, rng)
+            .map_err(AndError::Left)?
+            .into_iter()
+            .chain(self.rhs.select(population, rng).map_err(AndError::Right)?)
+            .collect())
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum AndError<L, R> {
+    #[error(transparent)]
+    Left(L),
+    #[error(transparent)]
+    Right(R),
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::operator::selector::best::Best;
+    use crate::core::operator::selector::first::First;
+    use crate::core::operator::selector::Selector;
+    use crate::core::population::Population;
+
+    #[test]
+    fn test_select() {
+        let population = [0, 1, 2, 3, 4];
+
+        let a = population.select(First.and(Best)).unwrap();
+        let b = population.select(Best.and(First)).unwrap();
+
+        assert_eq!(a, [0, 4]);
+        assert_eq!(b, [4, 0]);
+    }
+}

--- a/packages/brace-ec/src/core/operator/selector/mod.rs
+++ b/packages/brace-ec/src/core/operator/selector/mod.rs
@@ -1,3 +1,4 @@
+pub mod and;
 pub mod best;
 pub mod first;
 pub mod mutate;
@@ -10,6 +11,7 @@ use rand::Rng;
 use crate::core::fitness::{Fitness, FitnessMut};
 use crate::core::population::Population;
 
+use self::and::And;
 use self::mutate::Mutate;
 use self::recombine::Recombine;
 
@@ -57,6 +59,13 @@ pub trait Selector: Sized {
         <Self::Population as Population>::Individual: FitnessMut,
     {
         Score::new(self, scorer)
+    }
+
+    fn and<S>(self, selector: S) -> And<Self, S>
+    where
+        S: Selector<Population = Self::Population>,
+    {
+        And::new(self, selector)
     }
 
     fn then<S>(self, selector: S) -> Then<Self, S>


### PR DESCRIPTION
This adds a new `And` selector adapter to select from multiple selectors at once.

The `Then` operator adapter added in #45 provided the ability to compose two selectors together. However, the implementation used the second selector to select from the output of the first rather than select multiple individuals from the same population.

This change introduces a new `And` selector adapter that composes two selectors together and collects the outputs into a vector. This enables the ability to select multiple individuals at once using different selectors and finally makes recombinators useful.

The only issue with the implementation is that it returns a `Vec` but the crossover recombinators take a fixed-length array instead. This means that there either needs to be another adapter that outputs the correct number of individuals or this implementation needs to be updated to combine the outputs of the selectors, potentially returning an array or a vector.