### PR TITLE
Add `score_with` operator method

### DIFF
--- a/packages/brace-ec/src/core/operator/evolver/mod.rs
+++ b/packages/brace-ec/src/core/operator/evolver/mod.rs
@@ -7,6 +7,7 @@ use crate::core::population::Population;
 use super::inspect::Inspect;
 use super::repeat::Repeat;
 use super::score::Score;
+use super::scorer::function::Function;
 use super::scorer::Scorer;
 use super::then::Then;
 
@@ -26,6 +27,22 @@ pub trait Evolver {
         Self: Sized,
     {
         Score::new(self, scorer)
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn score_with<F, E>(
+        self,
+        scorer: F,
+    ) -> Score<Self, Function<F, <<Self::Generation as Generation>::Population as Population>::Individual>>
+    where
+        F: Fn(
+            &<<Self::Generation as Generation>::Population as Population>::Individual,
+        )
+            -> Result<<<<Self::Generation as Generation>::Population as Population>::Individual as Fitness>::Value, E>,
+        <<Self::Generation as Generation>::Population as Population>::Individual: FitnessMut,
+        Self: Sized,
+    {
+        self.score(Function::new(scorer))
     }
 
     fn then<E>(self, evolver: E) -> Then<Self, E>

--- a/packages/brace-ec/src/core/operator/mutator/mod.rs
+++ b/packages/brace-ec/src/core/operator/mutator/mod.rs
@@ -13,6 +13,7 @@ use self::rate::Rate;
 use super::inspect::Inspect;
 use super::repeat::Repeat;
 use super::score::Score;
+use super::scorer::function::Function;
 use super::scorer::Scorer;
 use super::then::Then;
 
@@ -34,6 +35,14 @@ pub trait Mutator: Sized {
         Self::Individual: FitnessMut,
     {
         Score::new(self, scorer)
+    }
+
+    fn score_with<F, E>(self, scorer: F) -> Score<Self, Function<F, Self::Individual>>
+    where
+        F: Fn(&Self::Individual) -> Result<<Self::Individual as Fitness>::Value, E>,
+        Self::Individual: FitnessMut,
+    {
+        self.score(Function::new(scorer))
     }
 
     fn then<M>(self, mutator: M) -> Then<Self, M>

--- a/packages/brace-ec/src/core/operator/recombinator/mod.rs
+++ b/packages/brace-ec/src/core/operator/recombinator/mod.rs
@@ -8,6 +8,7 @@ use crate::core::population::Population;
 use super::inspect::Inspect;
 use super::repeat::Repeat;
 use super::score::Score;
+use super::scorer::function::Function;
 use super::scorer::Scorer;
 use super::then::Then;
 
@@ -34,6 +35,20 @@ pub trait Recombinator {
         Self: Sized,
     {
         Score::new(self, scorer)
+    }
+
+    fn score_with<F, E>(
+        self,
+        scorer: F,
+    ) -> Score<Self, Function<F, <Self::Parents as Population>::Individual>>
+    where
+        F: Fn(
+            &<Self::Parents as Population>::Individual,
+        ) -> Result<<<Self::Parents as Population>::Individual as Fitness>::Value, E>,
+        <Self::Parents as Population>::Individual: FitnessMut,
+        Self: Sized,
+    {
+        self.score(Function::new(scorer))
     }
 
     fn then<R>(self, recombinator: R) -> Then<Self, R>

--- a/packages/brace-ec/src/core/operator/score.rs
+++ b/packages/brace-ec/src/core/operator/score.rs
@@ -203,9 +203,15 @@ mod tests {
         let b = population
             .select(First.score(Function::new(triple)))
             .unwrap()[0];
+        let c = population
+            .select(First.score_with(|individual: &Scored<i32, i32>| {
+                Ok::<_, Infallible>(individual.individual * 4)
+            }))
+            .unwrap()[0];
 
         assert_eq!(a, Scored::new(10, 20));
         assert_eq!(b, Scored::new(10, 30));
+        assert_eq!(c, Scored::new(10, 40));
     }
 
     #[test]
@@ -216,9 +222,15 @@ mod tests {
         let b = Scored::new(10, 0)
             .mutate(Add(5).score(Function::new(triple)))
             .unwrap();
+        let c = Scored::new(10, 0)
+            .mutate(Add(5).score_with(|individual: &Scored<i32, i32>| {
+                Ok::<_, Infallible>(individual.individual * 4)
+            }))
+            .unwrap();
 
         assert_eq!(a, Scored::new(15, 30));
         assert_eq!(b, Scored::new(15, 45));
+        assert_eq!(c, Scored::new(15, 60));
     }
 
     #[test]
@@ -231,9 +243,15 @@ mod tests {
         let b = population
             .recombine(Noop.score(Function::new(triple)))
             .unwrap();
+        let c = population
+            .recombine(Noop.score_with(|individual: &Scored<i32, i32>| {
+                Ok::<_, Infallible>(individual.individual * 4)
+            }))
+            .unwrap();
 
         assert_eq!(a, [Scored::new(10, 20), Scored::new(20, 40)]);
         assert_eq!(b, [Scored::new(10, 30), Scored::new(20, 60)]);
+        assert_eq!(c, [Scored::new(10, 40), Scored::new(20, 80)]);
     }
 
     #[test]
@@ -246,8 +264,15 @@ mod tests {
             .score(Function::new(triple))
             .evolve((0, [Scored::new(10, 0), Scored::new(20, 0)]))
             .unwrap();
+        let c = Select::new(First)
+            .score_with(|individual: &Scored<i32, i32>| {
+                Ok::<_, Infallible>(individual.individual * 4)
+            })
+            .evolve((0, [Scored::new(10, 0), Scored::new(20, 0)]))
+            .unwrap();
 
         assert_eq!(a, (1, [Scored::new(10, 20), Scored::new(10, 20)]));
         assert_eq!(b, (1, [Scored::new(10, 30), Scored::new(10, 30)]));
+        assert_eq!(c, (1, [Scored::new(10, 40), Scored::new(10, 40)]));
     }
 }

--- a/packages/brace-ec/src/core/operator/selector/mod.rs
+++ b/packages/brace-ec/src/core/operator/selector/mod.rs
@@ -20,6 +20,7 @@ use super::mutator::Mutator;
 use super::recombinator::Recombinator;
 use super::repeat::Repeat;
 use super::score::Score;
+use super::scorer::function::Function;
 use super::scorer::Scorer;
 use super::then::Then;
 
@@ -59,6 +60,20 @@ pub trait Selector: Sized {
         <Self::Population as Population>::Individual: FitnessMut,
     {
         Score::new(self, scorer)
+    }
+
+    fn score_with<F, E>(
+        self,
+        scorer: F,
+    ) -> Score<Self, Function<F, <Self::Population as Population>::Individual>>
+    where
+        F: Fn(
+            &<Self::Population as Population>::Individual,
+        )
+            -> Result<<<Self::Population as Population>::Individual as Fitness>::Value, E>,
+        <Self::Population as Population>::Individual: FitnessMut,
+    {
+        self.score(Function::new(scorer))
     }
 
     fn and<S>(self, selector: S) -> And<Self, S>


### PR DESCRIPTION
This adds a new `score_with` method to the various operators to simplify scoring with a function or closure.

The `Scorer` trait is not implemented on functions or closures and requires the use of the `Function` wrapper. The limitation was initially due to the use of an associated type instead of a generic but even if that were not the case the implementation would conflict when the various operators are implemented on references in a future update.

This change adds a new `score_with` method to the `Selector`, `Mutator`, `Recombinator` and `Evolver` operators that takes a function or closure instead of a scorer and automatically wraps it with the `Function` adapter. The trait bounds for this method are not very nice and there is work that could be done to clean it up. The implementation for `Evolver` is the most complex and requires the `clippy::type_complexity` lint to be allowed.