### PR TITLE
Add `TryFromIterator` helper trait

### DIFF
--- a/packages/brace-ec/src/util/iter.rs
+++ b/packages/brace-ec/src/util/iter.rs
@@ -1,3 +1,7 @@
+use std::convert::Infallible;
+
+use thiserror::Error;
+
 pub trait Iterable {
     type Item;
 
@@ -86,4 +90,56 @@ impl<T> IterableMut for Option<T> {
     fn iter_mut(&mut self) -> Self::IterMut<'_> {
         self.iter_mut()
     }
+}
+
+pub trait TryFromIterator<T>: Sized {
+    type Error;
+
+    fn try_from_iter<I>(iter: I) -> Result<Self, Self::Error>
+    where
+        I: IntoIterator<Item = T>;
+}
+
+impl<T, const N: usize> TryFromIterator<T> for [T; N] {
+    type Error = TryFromIteratorError;
+
+    fn try_from_iter<I>(iter: I) -> Result<Self, Self::Error>
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let mut iter = iter.into_iter();
+
+        match array_util::try_from_fn(|_| iter.next()) {
+            Some(arr) => Ok(arr),
+            None => Err(TryFromIteratorError::NotEnough),
+        }
+    }
+}
+
+impl<T> TryFromIterator<T> for Vec<T> {
+    type Error = Infallible;
+
+    fn try_from_iter<I>(iter: I) -> Result<Self, Self::Error>
+    where
+        I: IntoIterator<Item = T>,
+    {
+        Ok(iter.into_iter().collect())
+    }
+}
+
+impl<T> TryFromIterator<T> for Option<T> {
+    type Error = Infallible;
+
+    fn try_from_iter<I>(iter: I) -> Result<Self, Self::Error>
+    where
+        I: IntoIterator<Item = T>,
+    {
+        Ok(iter.into_iter().next())
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum TryFromIteratorError {
+    #[error("not enough items in iterator")]
+    NotEnough,
 }


### PR DESCRIPTION
This adds a new `TryFromIterator` helper trait to collect into supported collections.

The standard library provides the `FromIterator` trait that enables the ability for iterators to be collected into standard and third-party collections. However, there is no straight-forward way of collecting into an array of fixed length. Having this functionality would allow operators to collect straight into the desired type without intermediate allocations.

This change introduces the `TryFromIterator` trait and is implemented on the supported populations. As the populations expand it may be better to use a blanket implementation for all populations that implement `FromIterator` but for now this is enough. The implementation for arrays uses the `array-util` crate but it may be better to spin off this functionality into a separate crate without any extra dependencies.