### PR TITLE
Add `Take` selector adapter

### DIFF
--- a/packages/brace-ec/src/core/operator/selector/mod.rs
+++ b/packages/brace-ec/src/core/operator/selector/mod.rs
@@ -4,6 +4,7 @@ pub mod first;
 pub mod mutate;
 pub mod random;
 pub mod recombine;
+pub mod take;
 pub mod tournament;
 
 use rand::Rng;
@@ -14,6 +15,7 @@ use crate::core::population::Population;
 use self::and::And;
 use self::mutate::Mutate;
 use self::recombine::Recombine;
+use self::take::Take;
 
 use super::inspect::Inspect;
 use super::mutator::Mutator;
@@ -88,6 +90,13 @@ pub trait Selector: Sized {
         S: Selector<Population = Self::Output>,
     {
         Then::new(self, selector)
+    }
+
+    fn take<const N: usize>(self) -> Take<Self, N>
+    where
+        Self::Output: IntoIterator<Item = <Self::Population as Population>::Individual>,
+    {
+        Take::new(self)
     }
 
     fn repeat(self, count: usize) -> Repeat<Self>


### PR DESCRIPTION
This adds a new `Take` selector adapter to transform an output population into an array.

The point and uniform crossover recombinators currently take an array of 2 individuals as the input. However, there is no way to transform the output of a selector to the desired input so this limits the usability of those operators as they cannot be composed. For example, calling `Random.repeat(2)` will return 2 random individuals as a `Vec` and not an array so there is no way to recombine them using the crossover recombinators. Therefore there must be a way to transform the types.

An early experiment tried to automatically convert the output of one operator to the input of the next but this was deemed far too complex and caused issues with type inference.

It would technically be possible to implement the crossover recombinators for a `Vec` in addition to an array as the implementations would not overlap but doing so would cause issues with the type inference. The input type was set as an associated type instead of a generic for this reason as it should help prevent creating multiple implementations.

This change introduces the `Take` selector adapter and adds a utility method to the `Selector` trait to simplify composition.