### PR TITLE
Redesign `Scorer` trait

### DIFF
--- a/packages/brace-ec/src/core/operator/evolver/mod.rs
+++ b/packages/brace-ec/src/core/operator/evolver/mod.rs
@@ -20,7 +20,7 @@ pub trait Evolver {
     fn score<S>(self, scorer: S) -> Score<Self, S>
     where
         S: Scorer<
-            Individual = <<Self::Generation as Generation>::Population as Population>::Individual,
+            <<Self::Generation as Generation>::Population as Population>::Individual,
             Score = <<<Self::Generation as Generation>::Population as Population>::Individual as Fitness>::Value,
         >,
         <<Self::Generation as Generation>::Population as Population>::Individual: FitnessMut,
@@ -29,11 +29,10 @@ pub trait Evolver {
         Score::new(self, scorer)
     }
 
-    #[allow(clippy::type_complexity)]
     fn score_with<F, E>(
         self,
         scorer: F,
-    ) -> Score<Self, Function<F, <<Self::Generation as Generation>::Population as Population>::Individual>>
+    ) -> Score<Self, Function<F>>
     where
         F: Fn(
             &<<Self::Generation as Generation>::Population as Population>::Individual,

--- a/packages/brace-ec/src/core/operator/mutator/mod.rs
+++ b/packages/brace-ec/src/core/operator/mutator/mod.rs
@@ -31,13 +31,13 @@ pub trait Mutator: Sized {
 
     fn score<S>(self, scorer: S) -> Score<Self, S>
     where
-        S: Scorer<Individual = Self::Individual, Score = <Self::Individual as Fitness>::Value>,
+        S: Scorer<Self::Individual, Score = <Self::Individual as Fitness>::Value>,
         Self::Individual: FitnessMut,
     {
         Score::new(self, scorer)
     }
 
-    fn score_with<F, E>(self, scorer: F) -> Score<Self, Function<F, Self::Individual>>
+    fn score_with<F, E>(self, scorer: F) -> Score<Self, Function<F>>
     where
         F: Fn(&Self::Individual) -> Result<<Self::Individual as Fitness>::Value, E>,
         Self::Individual: FitnessMut,

--- a/packages/brace-ec/src/core/operator/recombinator/mod.rs
+++ b/packages/brace-ec/src/core/operator/recombinator/mod.rs
@@ -28,7 +28,7 @@ pub trait Recombinator {
     fn score<S>(self, scorer: S) -> Score<Self, S>
     where
         S: Scorer<
-            Individual = <Self::Parents as Population>::Individual,
+            <Self::Parents as Population>::Individual,
             Score = <<Self::Parents as Population>::Individual as Fitness>::Value,
         >,
         <Self::Parents as Population>::Individual: FitnessMut,
@@ -37,10 +37,7 @@ pub trait Recombinator {
         Score::new(self, scorer)
     }
 
-    fn score_with<F, E>(
-        self,
-        scorer: F,
-    ) -> Score<Self, Function<F, <Self::Parents as Population>::Individual>>
+    fn score_with<F, E>(self, scorer: F) -> Score<Self, Function<F>>
     where
         F: Fn(
             &<Self::Parents as Population>::Individual,

--- a/packages/brace-ec/src/core/operator/scorer/mod.rs
+++ b/packages/brace-ec/src/core/operator/scorer/mod.rs
@@ -2,10 +2,14 @@ pub mod function;
 
 use crate::core::individual::Individual;
 
-pub trait Scorer {
-    type Individual: Individual;
+pub trait Scorer<T>
+where
+    T: Individual,
+{
     type Score: Ord;
     type Error;
 
-    fn score(&self, individual: &Self::Individual) -> Result<Self::Score, Self::Error>;
+    fn score<Rng>(&self, input: &T, rng: &mut Rng) -> Result<Self::Score, Self::Error>
+    where
+        Rng: rand::Rng + ?Sized;
 }

--- a/packages/brace-ec/src/core/operator/selector/mod.rs
+++ b/packages/brace-ec/src/core/operator/selector/mod.rs
@@ -56,7 +56,7 @@ pub trait Selector: Sized {
     fn score<S>(self, scorer: S) -> Score<Self, S>
     where
         S: Scorer<
-            Individual = <Self::Population as Population>::Individual,
+            <Self::Population as Population>::Individual,
             Score = <<Self::Population as Population>::Individual as Fitness>::Value,
         >,
         <Self::Population as Population>::Individual: FitnessMut,
@@ -64,10 +64,7 @@ pub trait Selector: Sized {
         Score::new(self, scorer)
     }
 
-    fn score_with<F, E>(
-        self,
-        scorer: F,
-    ) -> Score<Self, Function<F, <Self::Population as Population>::Individual>>
+    fn score_with<F, E>(self, scorer: F) -> Score<Self, Function<F>>
     where
         F: Fn(
             &<Self::Population as Population>::Individual,


### PR DESCRIPTION
This redesigns the `Scorer` trait to take a generic instead of an associated type and support a random number generator.

The `Scorer` trait, like the other operator traits, uses an associated type as the input type instead of a generic. This meant that the sole implementation of the trait (`Function`) required a second generic to satisfy the type system. The intent behind this decision was to restrict implementors from being able to write multiple implementations because that would break type inference and there would be no easy way to specify the type that didn't involve a fully qualified method call. However, it is still technically possible to write multiple implementations on a type and break the type inference so the idea didn't quite work as intended.

This change updates the `Scorer` trait by moving the associated `Individual` type to a generic. It also adds a generic `Rng` on the method to be more like the other operator traits. This is part of a larger redesign that looks to replace the current system with a single `Operator` trait. The generic uses `Rng` instead of `R` to avoid confusion with other generic `R` types as it is commonly used to refer to a recombinator. This requires the fully qualified path to the trait but will often save an import.