### PR TITLE
Redesign `Mutator` trait

### DIFF
--- a/packages/brace-ec/src/core/individual/mod.rs
+++ b/packages/brace-ec/src/core/individual/mod.rs
@@ -15,7 +15,7 @@ pub trait Individual {
 
     fn mutate<M>(self, mutator: M) -> Result<Self, M::Error>
     where
-        M: Mutator<Individual = Self>,
+        M: Mutator<Self>,
         Self: Sized,
     {
         mutator.mutate(self, &mut thread_rng())

--- a/packages/brace-ec/src/core/operator/inspect.rs
+++ b/packages/brace-ec/src/core/operator/inspect.rs
@@ -42,21 +42,16 @@ where
     }
 }
 
-impl<T, F> Mutator for Inspect<T, F>
+impl<I, T, F> Mutator<I> for Inspect<T, F>
 where
-    T: Mutator,
-    F: Fn(&T::Individual),
+    T: Mutator<I>,
+    F: Fn(&I),
 {
-    type Individual = T::Individual;
     type Error = T::Error;
 
-    fn mutate<R>(
-        &self,
-        individual: Self::Individual,
-        rng: &mut R,
-    ) -> Result<Self::Individual, Self::Error>
+    fn mutate<Rng>(&self, individual: I, rng: &mut Rng) -> Result<I, Self::Error>
     where
-        R: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         self.operator
             .mutate(individual, rng)

--- a/packages/brace-ec/src/core/operator/inspect.rs
+++ b/packages/brace-ec/src/core/operator/inspect.rs
@@ -1,5 +1,7 @@
 use rand::Rng;
 
+use crate::core::individual::Individual;
+
 use super::evolver::Evolver;
 use super::mutator::Mutator;
 use super::recombinator::Recombinator;
@@ -44,6 +46,7 @@ where
 
 impl<I, T, F> Mutator<I> for Inspect<T, F>
 where
+    I: Individual,
     T: Mutator<I>,
     F: Fn(&I),
 {

--- a/packages/brace-ec/src/core/operator/mutator/add.rs
+++ b/packages/brace-ec/src/core/operator/mutator/add.rs
@@ -1,5 +1,4 @@
 use num_traits::{CheckedAdd, One};
-use rand::Rng;
 use thiserror::Error;
 
 use crate::core::individual::Individual;
@@ -9,20 +8,15 @@ use super::Mutator;
 #[derive(Clone, Copy, Debug)]
 pub struct Add<I: Individual>(pub I::Genome);
 
-impl<I> Mutator for Add<I>
+impl<I> Mutator<I> for Add<I>
 where
     I: Individual<Genome: CheckedAdd>,
 {
-    type Individual = I;
     type Error = AddError;
 
-    fn mutate<R>(
-        &self,
-        mut individual: Self::Individual,
-        _: &mut R,
-    ) -> Result<Self::Individual, Self::Error>
+    fn mutate<Rng>(&self, mut individual: I, _: &mut Rng) -> Result<I, Self::Error>
     where
-        R: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         let genome = individual
             .genome()

--- a/packages/brace-ec/src/core/operator/mutator/invert.rs
+++ b/packages/brace-ec/src/core/operator/mutator/invert.rs
@@ -1,8 +1,6 @@
 use std::convert::Infallible;
 use std::ops::Not;
 
-use rand::Rng;
-
 use crate::core::individual::Individual;
 
 use super::Mutator;
@@ -11,20 +9,15 @@ use super::Mutator;
 #[derive(Clone, Copy, Debug)]
 pub struct Invert<I: Individual>;
 
-impl<I> Mutator for Invert<I>
+impl<I> Mutator<I> for Invert<I>
 where
     I: Individual + Not<Output = I>,
 {
-    type Individual = I;
     type Error = Infallible;
 
-    fn mutate<R>(
-        &self,
-        individual: Self::Individual,
-        _: &mut R,
-    ) -> Result<Self::Individual, Self::Error>
+    fn mutate<Rng>(&self, individual: I, _: &mut Rng) -> Result<I, Self::Error>
     where
-        R: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         Ok(individual.not())
     }

--- a/packages/brace-ec/src/core/operator/mutator/mod.rs
+++ b/packages/brace-ec/src/core/operator/mutator/mod.rs
@@ -48,24 +48,17 @@ where
         Then::new(self, mutator)
     }
 
-    fn rate(self, rate: f64) -> Rate<Self>
-    where
-        Self: Sized,
-    {
+    fn rate(self, rate: f64) -> Rate<Self> {
         Rate::new(self, rate)
     }
 
-    fn repeat(self, count: usize) -> Repeat<Self>
-    where
-        Self: Sized,
-    {
+    fn repeat(self, count: usize) -> Repeat<Self> {
         Repeat::new(self, count)
     }
 
     fn inspect<F>(self, inspector: F) -> Inspect<Self, F>
     where
         F: Fn(&T),
-        Self: Sized,
     {
         Inspect::new(self, inspector)
     }

--- a/packages/brace-ec/src/core/operator/mutator/mod.rs
+++ b/packages/brace-ec/src/core/operator/mutator/mod.rs
@@ -4,6 +4,7 @@ pub mod noise;
 pub mod rate;
 
 use crate::core::fitness::FitnessMut;
+use crate::core::individual::Individual;
 
 use self::rate::Rate;
 
@@ -14,7 +15,10 @@ use super::scorer::function::Function;
 use super::scorer::Scorer;
 use super::then::Then;
 
-pub trait Mutator<T>: Sized {
+pub trait Mutator<T>: Sized
+where
+    T: Individual,
+{
     type Error;
 
     fn mutate<Rng>(&self, individual: T, rng: &mut Rng) -> Result<T, Self::Error>

--- a/packages/brace-ec/src/core/operator/mutator/noise.rs
+++ b/packages/brace-ec/src/core/operator/mutator/noise.rs
@@ -3,7 +3,6 @@ use std::ops::{Add, Range, RangeBounds};
 
 use num_traits::{Bounded, One, SaturatingAdd, SaturatingSub};
 use rand::distributions::uniform::SampleUniform;
-use rand::Rng;
 
 use crate::core::individual::Individual;
 use crate::util::range::get_range;
@@ -28,21 +27,16 @@ where
     }
 }
 
-impl<T> Mutator for Noise<T>
+impl<T> Mutator<T> for Noise<T>
 where
     T: Individual,
     T::Genome: Clone + PartialOrd + SaturatingAdd + SaturatingSub + SampleUniform,
 {
-    type Individual = T;
     type Error = Infallible;
 
-    fn mutate<R>(
-        &self,
-        mut individual: Self::Individual,
-        rng: &mut R,
-    ) -> Result<Self::Individual, Self::Error>
+    fn mutate<Rng>(&self, mut individual: T, rng: &mut Rng) -> Result<T, Self::Error>
     where
-        R: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         let genome = match rng.gen_bool(0.5) {
             true => individual

--- a/packages/brace-ec/src/core/operator/mutator/rate.rs
+++ b/packages/brace-ec/src/core/operator/mutator/rate.rs
@@ -1,5 +1,3 @@
-use rand::Rng;
-
 use super::Mutator;
 
 pub struct Rate<M> {
@@ -13,20 +11,15 @@ impl<M> Rate<M> {
     }
 }
 
-impl<M> Mutator for Rate<M>
+impl<T, M> Mutator<T> for Rate<M>
 where
-    M: Mutator,
+    M: Mutator<T>,
 {
-    type Individual = M::Individual;
     type Error = M::Error;
 
-    fn mutate<R>(
-        &self,
-        individual: Self::Individual,
-        rng: &mut R,
-    ) -> Result<Self::Individual, Self::Error>
+    fn mutate<Rng>(&self, individual: T, rng: &mut Rng) -> Result<T, Self::Error>
     where
-        R: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         if rng.gen_bool(self.rate) {
             self.mutator.mutate(individual, rng)

--- a/packages/brace-ec/src/core/operator/mutator/rate.rs
+++ b/packages/brace-ec/src/core/operator/mutator/rate.rs
@@ -1,3 +1,5 @@
+use crate::core::individual::Individual;
+
 use super::Mutator;
 
 pub struct Rate<M> {
@@ -14,6 +16,7 @@ impl<M> Rate<M> {
 impl<T, M> Mutator<T> for Rate<M>
 where
     M: Mutator<T>,
+    T: Individual,
 {
     type Error = M::Error;
 

--- a/packages/brace-ec/src/core/operator/repeat.rs
+++ b/packages/brace-ec/src/core/operator/repeat.rs
@@ -44,20 +44,15 @@ where
     }
 }
 
-impl<T> Mutator for Repeat<T>
+impl<I, T> Mutator<I> for Repeat<T>
 where
-    T: Mutator,
+    T: Mutator<I>,
 {
-    type Individual = T::Individual;
     type Error = T::Error;
 
-    fn mutate<R>(
-        &self,
-        mut individual: Self::Individual,
-        rng: &mut R,
-    ) -> Result<Self::Individual, Self::Error>
+    fn mutate<Rng>(&self, mut individual: I, rng: &mut Rng) -> Result<I, Self::Error>
     where
-        R: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         for _ in 0..self.count {
             individual = self.operator.mutate(individual, rng)?;

--- a/packages/brace-ec/src/core/operator/repeat.rs
+++ b/packages/brace-ec/src/core/operator/repeat.rs
@@ -1,5 +1,6 @@
 use rand::Rng;
 
+use crate::core::individual::Individual;
 use crate::core::population::Population;
 
 use super::evolver::Evolver;
@@ -47,6 +48,7 @@ where
 impl<I, T> Mutator<I> for Repeat<T>
 where
     T: Mutator<I>,
+    I: Individual,
 {
     type Error = T::Error;
 

--- a/packages/brace-ec/src/core/operator/score.rs
+++ b/packages/brace-ec/src/core/operator/score.rs
@@ -54,22 +54,17 @@ where
     }
 }
 
-impl<T, S, I> Mutator for Score<T, S>
+impl<T, S, I> Mutator<I> for Score<T, S>
 where
-    T: Mutator<Individual = I>,
+    T: Mutator<I>,
     S: Scorer<I, Score = I::Value>,
     I: FitnessMut,
 {
-    type Individual = T::Individual;
     type Error = ScoreError<T::Error, S::Error>;
 
-    fn mutate<R>(
-        &self,
-        individual: Self::Individual,
-        rng: &mut R,
-    ) -> Result<Self::Individual, Self::Error>
+    fn mutate<Rng>(&self, individual: I, rng: &mut Rng) -> Result<I, Self::Error>
     where
-        R: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         let individual = self
             .operator

--- a/packages/brace-ec/src/core/operator/selector/mod.rs
+++ b/packages/brace-ec/src/core/operator/selector/mod.rs
@@ -41,7 +41,7 @@ pub trait Selector: Sized {
 
     fn mutate<M>(self, mutator: M) -> Mutate<Self, M>
     where
-        M: Mutator<Individual = <Self::Population as Population>::Individual>,
+        M: Mutator<<Self::Population as Population>::Individual>,
     {
         Mutate::new(self, mutator)
     }

--- a/packages/brace-ec/src/core/operator/selector/mutate.rs
+++ b/packages/brace-ec/src/core/operator/selector/mutate.rs
@@ -21,7 +21,7 @@ impl<S, M> Mutate<S, M> {
 impl<S, M> Selector for Mutate<S, M>
 where
     S: Selector<Output: TryMap<Item = <S::Population as Population>::Individual>>,
-    M: Mutator<Individual = <S::Population as Population>::Individual>,
+    M: Mutator<<S::Population as Population>::Individual>,
 {
     type Population = S::Population;
     type Output = S::Output;

--- a/packages/brace-ec/src/core/operator/then.rs
+++ b/packages/brace-ec/src/core/operator/then.rs
@@ -40,21 +40,16 @@ where
     }
 }
 
-impl<L, R> Mutator for Then<L, R>
+impl<T, L, R> Mutator<T> for Then<L, R>
 where
-    L: Mutator,
-    R: Mutator<Individual = L::Individual>,
+    L: Mutator<T>,
+    R: Mutator<T>,
 {
-    type Individual = L::Individual;
     type Error = ThenError<L::Error, R::Error>;
 
-    fn mutate<G>(
-        &self,
-        individual: Self::Individual,
-        rng: &mut G,
-    ) -> Result<Self::Individual, Self::Error>
+    fn mutate<Rng>(&self, individual: T, rng: &mut Rng) -> Result<T, Self::Error>
     where
-        G: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         self.rhs
             .mutate(

--- a/packages/brace-ec/src/core/operator/then.rs
+++ b/packages/brace-ec/src/core/operator/then.rs
@@ -1,6 +1,8 @@
 use rand::Rng;
 use thiserror::Error;
 
+use crate::core::individual::Individual;
+
 use super::evolver::Evolver;
 use super::mutator::Mutator;
 use super::recombinator::Recombinator;
@@ -42,6 +44,7 @@ where
 
 impl<T, L, R> Mutator<T> for Then<L, R>
 where
+    T: Individual,
     L: Mutator<T>,
     R: Mutator<T>,
 {


### PR DESCRIPTION
This redesigns the `Mutator` trait following the changes to `Scorer`.

The `Mutator` trait, like other operator traits, uses an associated `Individual` rather than a generic. The intent behind this design was to limit the implementations of the trait to one per type to not break type inference. However, it is still possible to write multiple implementations and the use of an associated input greatly impacts the readability of trait bounds.

This change updates the `Mutator` trait to replace the associated `Individual` with a generic `T`. It also renames the generic `R` to `Rng` and tweaks the bound to use the fully qualified path. This ensures that it is consistent with the `Scorer` trait. It does not adjust the other generic letters as used by the various implementations.