### PR TITLE
Redesign `Recombinator` trait

### DIFF
--- a/packages/brace-ec/src/core/operator/inspect.rs
+++ b/packages/brace-ec/src/core/operator/inspect.rs
@@ -1,6 +1,7 @@
 use rand::Rng;
 
 use crate::core::individual::Individual;
+use crate::core::population::Population;
 
 use super::evolver::Evolver;
 use super::mutator::Mutator;
@@ -62,18 +63,18 @@ where
     }
 }
 
-impl<T, F> Recombinator for Inspect<T, F>
+impl<P, T, F> Recombinator<P> for Inspect<T, F>
 where
-    T: Recombinator,
+    P: Population,
+    T: Recombinator<P>,
     F: Fn(&T::Output),
 {
-    type Parents = T::Parents;
     type Output = T::Output;
     type Error = T::Error;
 
-    fn recombine<R>(&self, parents: Self::Parents, rng: &mut R) -> Result<Self::Output, Self::Error>
+    fn recombine<Rng>(&self, parents: P, rng: &mut Rng) -> Result<Self::Output, Self::Error>
     where
-        R: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         self.operator
             .recombine(parents, rng)

--- a/packages/brace-ec/src/core/operator/recombinator/mod.rs
+++ b/packages/brace-ec/src/core/operator/recombinator/mod.rs
@@ -1,7 +1,5 @@
 pub mod sum;
 
-use rand::Rng;
-
 use crate::core::fitness::{Fitness, FitnessMut};
 use crate::core::population::Population;
 
@@ -12,61 +10,47 @@ use super::scorer::function::Function;
 use super::scorer::Scorer;
 use super::then::Then;
 
-pub trait Recombinator {
-    type Parents: Population;
-    type Output: Population<Individual = <Self::Parents as Population>::Individual>;
+pub trait Recombinator<P>: Sized
+where
+    P: Population,
+{
+    type Output: Population<Individual = P::Individual>;
     type Error;
 
-    fn recombine<R>(
-        &self,
-        parents: Self::Parents,
-        rng: &mut R,
-    ) -> Result<Self::Output, Self::Error>
+    fn recombine<Rng>(&self, parents: P, rng: &mut Rng) -> Result<Self::Output, Self::Error>
     where
-        R: Rng + ?Sized;
+        Rng: rand::Rng + ?Sized;
 
     fn score<S>(self, scorer: S) -> Score<Self, S>
     where
-        S: Scorer<
-            <Self::Parents as Population>::Individual,
-            Score = <<Self::Parents as Population>::Individual as Fitness>::Value,
-        >,
-        <Self::Parents as Population>::Individual: FitnessMut,
-        Self: Sized,
+        S: Scorer<P::Individual, Score = <P::Individual as Fitness>::Value>,
+        P::Individual: FitnessMut,
     {
         Score::new(self, scorer)
     }
 
     fn score_with<F, E>(self, scorer: F) -> Score<Self, Function<F>>
     where
-        F: Fn(
-            &<Self::Parents as Population>::Individual,
-        ) -> Result<<<Self::Parents as Population>::Individual as Fitness>::Value, E>,
-        <Self::Parents as Population>::Individual: FitnessMut,
-        Self: Sized,
+        F: Fn(&P::Individual) -> Result<<P::Individual as Fitness>::Value, E>,
+        P::Individual: FitnessMut,
     {
         self.score(Function::new(scorer))
     }
 
     fn then<R>(self, recombinator: R) -> Then<Self, R>
     where
-        R: Recombinator<Parents = Self::Output>,
-        Self: Sized,
+        R: Recombinator<Self::Output>,
     {
         Then::new(self, recombinator)
     }
 
-    fn repeat(self, count: usize) -> Repeat<Self>
-    where
-        Self: Sized,
-    {
+    fn repeat(self, count: usize) -> Repeat<Self> {
         Repeat::new(self, count)
     }
 
     fn inspect<F>(self, inspector: F) -> Inspect<Self, F>
     where
         F: Fn(&Self::Output),
-        Self: Sized,
     {
         Inspect::new(self, inspector)
     }

--- a/packages/brace-ec/src/core/operator/recombinator/sum.rs
+++ b/packages/brace-ec/src/core/operator/recombinator/sum.rs
@@ -1,4 +1,3 @@
-use rand::Rng;
 use thiserror::Error;
 
 use crate::core::population::Population;
@@ -10,17 +9,16 @@ use super::Recombinator;
 #[derive(Clone, Copy, Debug)]
 pub struct Sum<P: Population>;
 
-impl<P> Recombinator for Sum<P>
+impl<P> Recombinator<P> for Sum<P>
 where
     P: Population + CheckedSum<P::Individual>,
 {
-    type Parents = P;
     type Output = [P::Individual; 1];
     type Error = SumError;
 
-    fn recombine<R>(&self, parents: Self::Parents, _: &mut R) -> Result<Self::Output, Self::Error>
+    fn recombine<Rng>(&self, parents: P, _: &mut Rng) -> Result<Self::Output, Self::Error>
     where
-        R: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         Ok([parents.checked_sum().ok_or(SumError::Overflow)?])
     }

--- a/packages/brace-ec/src/core/operator/repeat.rs
+++ b/packages/brace-ec/src/core/operator/repeat.rs
@@ -64,22 +64,17 @@ where
     }
 }
 
-impl<T, P> Recombinator for Repeat<T>
+impl<T, P> Recombinator<P> for Repeat<T>
 where
-    T: Recombinator<Parents = P, Output = P>,
+    T: Recombinator<P, Output = P>,
     P: Population,
 {
-    type Parents = P;
     type Output = P;
     type Error = T::Error;
 
-    fn recombine<R>(
-        &self,
-        mut parents: Self::Parents,
-        rng: &mut R,
-    ) -> Result<Self::Output, Self::Error>
+    fn recombine<Rng>(&self, mut parents: P, rng: &mut Rng) -> Result<Self::Output, Self::Error>
     where
-        R: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         for _ in 0..self.count {
             parents = self.operator.recombine(parents, rng)?;
@@ -109,8 +104,6 @@ where
 mod tests {
     use std::convert::Infallible;
 
-    use rand::Rng;
-
     use crate::core::individual::Individual;
     use crate::core::operator::evolver::select::Select;
     use crate::core::operator::evolver::Evolver;
@@ -123,18 +116,13 @@ mod tests {
 
     struct Swap;
 
-    impl Recombinator for Swap {
-        type Parents = [u8; 2];
+    impl Recombinator<[u8; 2]> for Swap {
         type Output = [u8; 2];
         type Error = Infallible;
 
-        fn recombine<R>(
-            &self,
-            parents: Self::Parents,
-            _: &mut R,
-        ) -> Result<Self::Output, Self::Error>
+        fn recombine<Rng>(&self, parents: [u8; 2], _: &mut Rng) -> Result<Self::Output, Self::Error>
         where
-            R: Rng + ?Sized,
+            Rng: rand::Rng + ?Sized,
         {
             Ok([parents[1], parents[0]])
         }

--- a/packages/brace-ec/src/core/operator/score.rs
+++ b/packages/brace-ec/src/core/operator/score.rs
@@ -80,19 +80,19 @@ where
     }
 }
 
-impl<T, S, I> Recombinator for Score<T, S>
+impl<P, T, S, I> Recombinator<P> for Score<T, S>
 where
-    T: Recombinator<Parents: Population<Individual = I>, Output: TryMap<Item = I>>,
+    P: Population<Individual = I>,
+    T: Recombinator<P, Output: TryMap<Item = I>>,
     S: Scorer<I, Score = I::Value>,
     I: FitnessMut,
 {
-    type Parents = T::Parents;
     type Output = T::Output;
     type Error = ScoreError<T::Error, S::Error>;
 
-    fn recombine<R>(&self, parents: Self::Parents, rng: &mut R) -> Result<Self::Output, Self::Error>
+    fn recombine<Rng>(&self, parents: P, rng: &mut Rng) -> Result<Self::Output, Self::Error>
     where
-        R: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         self.operator
             .recombine(parents, rng)
@@ -151,8 +151,6 @@ pub enum ScoreError<O, S> {
 mod tests {
     use std::convert::Infallible;
 
-    use rand::Rng;
-
     use crate::core::individual::scored::Scored;
     use crate::core::individual::Individual;
     use crate::core::operator::evolver::select::Select;
@@ -175,18 +173,17 @@ mod tests {
 
     struct Noop;
 
-    impl Recombinator for Noop {
-        type Parents = [Scored<i32, i32>; 2];
+    impl Recombinator<[Scored<i32, i32>; 2]> for Noop {
         type Output = [Scored<i32, i32>; 2];
         type Error = Infallible;
 
-        fn recombine<R>(
+        fn recombine<Rng>(
             &self,
-            parents: Self::Parents,
-            _: &mut R,
+            parents: [Scored<i32, i32>; 2],
+            _: &mut Rng,
         ) -> Result<Self::Output, Self::Error>
         where
-            R: Rng + ?Sized,
+            Rng: rand::Rng + ?Sized,
         {
             Ok(parents)
         }

--- a/packages/brace-ec/src/core/operator/selector/mod.rs
+++ b/packages/brace-ec/src/core/operator/selector/mod.rs
@@ -48,7 +48,7 @@ pub trait Selector: Sized {
 
     fn recombine<R>(self, recombinator: R) -> Recombine<Self, R>
     where
-        R: Recombinator<Parents = Self::Output>,
+        R: Recombinator<Self::Output>,
     {
         Recombine::new(self, recombinator)
     }

--- a/packages/brace-ec/src/core/operator/selector/recombine.rs
+++ b/packages/brace-ec/src/core/operator/selector/recombine.rs
@@ -22,7 +22,7 @@ impl<S, R> Recombine<S, R> {
 impl<S, R> Selector for Recombine<S, R>
 where
     S: Selector,
-    R: Recombinator<Parents = S::Output>,
+    R: Recombinator<S::Output>,
 {
     type Population = S::Population;
     type Output = R::Output;

--- a/packages/brace-ec/src/core/operator/selector/take.rs
+++ b/packages/brace-ec/src/core/operator/selector/take.rs
@@ -53,8 +53,6 @@ pub enum TakeError<S> {
 mod tests {
     use std::convert::Infallible;
 
-    use rand::Rng;
-
     use crate::core::operator::recombinator::Recombinator;
     use crate::core::operator::selector::best::Best;
     use crate::core::operator::selector::Selector;
@@ -62,18 +60,13 @@ mod tests {
 
     struct Swap;
 
-    impl Recombinator for Swap {
-        type Parents = [u8; 2];
+    impl Recombinator<[u8; 2]> for Swap {
         type Output = [u8; 2];
         type Error = Infallible;
 
-        fn recombine<R>(
-            &self,
-            parents: Self::Parents,
-            _: &mut R,
-        ) -> Result<Self::Output, Self::Error>
+        fn recombine<Rng>(&self, parents: [u8; 2], _: &mut Rng) -> Result<Self::Output, Self::Error>
         where
-            R: Rng + ?Sized,
+            Rng: rand::Rng + ?Sized,
         {
             Ok([parents[1], parents[0]])
         }

--- a/packages/brace-ec/src/core/population.rs
+++ b/packages/brace-ec/src/core/population.rs
@@ -24,7 +24,7 @@ pub trait Population {
 
     fn recombine<R>(self, recombinator: R) -> Result<R::Output, R::Error>
     where
-        R: Recombinator<Parents = Self>,
+        R: Recombinator<Self>,
         Self: Sized,
     {
         recombinator.recombine(self, &mut thread_rng())

--- a/packages/brace-ec/src/linear/operator/recombinator/point.rs
+++ b/packages/brace-ec/src/linear/operator/recombinator/point.rs
@@ -1,7 +1,6 @@
 use std::marker::PhantomData;
 
 use rand::seq::IteratorRandom;
-use rand::Rng;
 use thiserror::Error;
 
 use crate::core::individual::Individual;
@@ -14,21 +13,20 @@ use crate::linear::crossover::Crossover;
 #[derive(Clone, Copy, Debug)]
 pub struct OnePointCrossover<P: Population>;
 
-impl<I> Recombinator for OnePointCrossover<[I; 2]>
+impl<I> Recombinator<[I; 2]> for OnePointCrossover<[I; 2]>
 where
     I: Individual<Genome: Crossover>,
 {
-    type Parents = [I; 2];
     type Output = [I; 2];
     type Error = PointCrossoverError;
 
-    fn recombine<R>(
+    fn recombine<Rng>(
         &self,
-        [mut lhs, mut rhs]: Self::Parents,
-        rng: &mut R,
+        [mut lhs, mut rhs]: [I; 2],
+        rng: &mut Rng,
     ) -> Result<Self::Output, Self::Error>
     where
-        R: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         if lhs.genome().len() != rhs.genome().len() {
             return Err(PointCrossoverError::MixedLength);
@@ -51,21 +49,20 @@ where
 #[derive(Clone, Copy, Debug)]
 pub struct TwoPointCrossover<P: Population>;
 
-impl<I> Recombinator for TwoPointCrossover<[I; 2]>
+impl<I> Recombinator<[I; 2]> for TwoPointCrossover<[I; 2]>
 where
     I: Individual<Genome: Crossover>,
 {
-    type Parents = [I; 2];
     type Output = [I; 2];
     type Error = PointCrossoverError;
 
-    fn recombine<R>(
+    fn recombine<Rng>(
         &self,
-        [mut lhs, mut rhs]: Self::Parents,
-        rng: &mut R,
+        [mut lhs, mut rhs]: [I; 2],
+        rng: &mut Rng,
     ) -> Result<Self::Output, Self::Error>
     where
-        R: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         if lhs.genome().len() != rhs.genome().len() {
             return Err(PointCrossoverError::MixedLength);
@@ -102,17 +99,16 @@ where
     }
 }
 
-impl<I> Recombinator for MultiPointCrossover<[I; 2]>
+impl<I> Recombinator<[I; 2]> for MultiPointCrossover<[I; 2]>
 where
     I: Individual<Genome: Crossover>,
 {
-    type Parents = [I; 2];
     type Output = [I; 2];
     type Error = PointCrossoverError;
 
-    fn recombine<R>(&self, parents: Self::Parents, rng: &mut R) -> Result<Self::Output, Self::Error>
+    fn recombine<Rng>(&self, parents: [I; 2], rng: &mut Rng) -> Result<Self::Output, Self::Error>
     where
-        R: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         match self.count {
             0 => Ok(parents),

--- a/packages/brace-ec/src/linear/operator/recombinator/uniform.rs
+++ b/packages/brace-ec/src/linear/operator/recombinator/uniform.rs
@@ -1,6 +1,5 @@
 use std::marker::PhantomData;
 
-use rand::Rng;
 use thiserror::Error;
 
 use crate::core::individual::Individual;
@@ -26,21 +25,20 @@ where
     }
 }
 
-impl<I> Recombinator for UniformCrossover<[I; 2]>
+impl<I> Recombinator<[I; 2]> for UniformCrossover<[I; 2]>
 where
     I: Individual<Genome: Crossover>,
 {
-    type Parents = [I; 2];
     type Output = [I; 2];
     type Error = UniformCrossoverError;
 
-    fn recombine<R>(
+    fn recombine<Rng>(
         &self,
-        [mut lhs, mut rhs]: Self::Parents,
-        rng: &mut R,
+        [mut lhs, mut rhs]: [I; 2],
+        rng: &mut Rng,
     ) -> Result<Self::Output, Self::Error>
     where
-        R: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         if lhs.genome().len() != rhs.genome().len() {
             return Err(UniformCrossoverError::MixedLength);


### PR DESCRIPTION
This redesigns the `Recombinator` trait following the changes to `Scorer` and `Mutator`.

The `Recombinator` trait, like other operator traits, uses an associated type as the input rather than a generic. The intent behind this design was to limit the implementations of the trait to one per type to not break type inference. However, it is still possible to write multiple implementations and the use of an associated input greatly impacts the readability of trait bounds.

This change updates the `Recombinator` trait to replace the associated `Population` with a generic `P`. It also renames the generic `R` to `Rng` and tweaks the bound to use the fully qualified path. This ensures that it is consistent with the `Scorer` and `Mutator` traits. It does not adjust the other generic letters as used by the various implementations.