### PR TITLE
Redesign `Selector` trait

### DIFF
--- a/packages/brace-ec/src/core/operator/inspect.rs
+++ b/packages/brace-ec/src/core/operator/inspect.rs
@@ -1,5 +1,3 @@
-use rand::Rng;
-
 use crate::core::individual::Individual;
 use crate::core::population::Population;
 
@@ -22,22 +20,18 @@ impl<T, F> Inspect<T, F> {
     }
 }
 
-impl<T, F> Selector for Inspect<T, F>
+impl<P, T, F> Selector<P> for Inspect<T, F>
 where
-    T: Selector,
+    P: Population,
+    T: Selector<P>,
     F: Fn(&T::Output),
 {
-    type Population = T::Population;
     type Output = T::Output;
     type Error = T::Error;
 
-    fn select<R>(
-        &self,
-        population: &Self::Population,
-        rng: &mut R,
-    ) -> Result<Self::Output, Self::Error>
+    fn select<Rng>(&self, population: &P, rng: &mut Rng) -> Result<Self::Output, Self::Error>
     where
-        R: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         self.operator
             .select(population, rng)

--- a/packages/brace-ec/src/core/operator/repeat.rs
+++ b/packages/brace-ec/src/core/operator/repeat.rs
@@ -1,5 +1,3 @@
-use rand::Rng;
-
 use crate::core::individual::Individual;
 use crate::core::population::Population;
 
@@ -19,21 +17,17 @@ impl<T> Repeat<T> {
     }
 }
 
-impl<T> Selector for Repeat<T>
+impl<P, T> Selector<P> for Repeat<T>
 where
-    T: Selector<Output: IntoIterator<Item = <T::Population as Population>::Individual>>,
+    P: Population,
+    T: Selector<P, Output: IntoIterator<Item = P::Individual>>,
 {
-    type Population = T::Population;
-    type Output = Vec<<T::Population as Population>::Individual>;
+    type Output = Vec<P::Individual>;
     type Error = T::Error;
 
-    fn select<R>(
-        &self,
-        population: &Self::Population,
-        rng: &mut R,
-    ) -> Result<Self::Output, Self::Error>
+    fn select<Rng>(&self, population: &P, rng: &mut Rng) -> Result<Self::Output, Self::Error>
     where
-        R: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         let mut individuals = Vec::with_capacity(self.count);
 

--- a/packages/brace-ec/src/core/operator/score.rs
+++ b/packages/brace-ec/src/core/operator/score.rs
@@ -1,4 +1,4 @@
-use rand::{thread_rng, Rng};
+use rand::thread_rng;
 use thiserror::Error;
 
 use crate::core::fitness::FitnessMut;
@@ -24,23 +24,19 @@ impl<T, S> Score<T, S> {
     }
 }
 
-impl<T, S, I> Selector for Score<T, S>
+impl<P, T, S, I> Selector<P> for Score<T, S>
 where
-    T: Selector<Population: Population<Individual = I>, Output: TryMap<Item = I>>,
+    P: Population<Individual = I>,
+    T: Selector<P, Output: TryMap<Item = I>>,
     S: Scorer<I, Score = I::Value>,
     I: FitnessMut,
 {
-    type Population = T::Population;
     type Output = T::Output;
     type Error = ScoreError<T::Error, S::Error>;
 
-    fn select<R>(
-        &self,
-        population: &Self::Population,
-        rng: &mut R,
-    ) -> Result<Self::Output, Self::Error>
+    fn select<Rng>(&self, population: &P, rng: &mut Rng) -> Result<Self::Output, Self::Error>
     where
-        R: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         self.operator
             .select(population, rng)

--- a/packages/brace-ec/src/core/operator/selector/and.rs
+++ b/packages/brace-ec/src/core/operator/selector/and.rs
@@ -1,4 +1,3 @@
-use rand::Rng;
 use thiserror::Error;
 
 use crate::core::population::Population;
@@ -16,25 +15,18 @@ impl<L, R> And<L, R> {
     }
 }
 
-impl<L, R> Selector for And<L, R>
+impl<P, L, R> Selector<P> for And<L, R>
 where
-    L: Selector<Output: IntoIterator<Item = <L::Population as Population>::Individual>>,
-    R: Selector<
-        Population = L::Population,
-        Output: IntoIterator<Item = <L::Population as Population>::Individual>,
-    >,
+    P: Population,
+    L: Selector<P, Output: IntoIterator<Item = P::Individual>>,
+    R: Selector<P, Output: IntoIterator<Item = P::Individual>>,
 {
-    type Population = L::Population;
-    type Output = Vec<<L::Population as Population>::Individual>;
+    type Output = Vec<P::Individual>;
     type Error = AndError<L::Error, R::Error>;
 
-    fn select<G>(
-        &self,
-        population: &Self::Population,
-        rng: &mut G,
-    ) -> Result<Self::Output, Self::Error>
+    fn select<Rng>(&self, population: &P, rng: &mut Rng) -> Result<Self::Output, Self::Error>
     where
-        G: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         Ok(self
             .lhs

--- a/packages/brace-ec/src/core/operator/selector/best.rs
+++ b/packages/brace-ec/src/core/operator/selector/best.rs
@@ -1,4 +1,3 @@
-use rand::Rng;
 use thiserror::Error;
 
 use crate::core::fitness::Fitness;
@@ -10,17 +9,16 @@ use super::Selector;
 #[derive(Clone, Copy, Debug)]
 pub struct Best<P: Population>;
 
-impl<P> Selector for Best<P>
+impl<P> Selector<P> for Best<P>
 where
     P: IterablePopulation<Individual: Clone + Fitness>,
 {
-    type Population = P;
     type Output = [P::Individual; 1];
     type Error = BestError;
 
-    fn select<R>(&self, population: &P, _: &mut R) -> Result<Self::Output, Self::Error>
+    fn select<Rng>(&self, population: &P, _: &mut Rng) -> Result<Self::Output, Self::Error>
     where
-        R: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         Ok([population
             .iter()

--- a/packages/brace-ec/src/core/operator/selector/first.rs
+++ b/packages/brace-ec/src/core/operator/selector/first.rs
@@ -1,4 +1,3 @@
-use rand::Rng;
 use thiserror::Error;
 
 use crate::core::population::IterablePopulation;
@@ -9,17 +8,16 @@ use super::Selector;
 #[derive(Clone, Copy, Debug)]
 pub struct First<P: IterablePopulation>;
 
-impl<P> Selector for First<P>
+impl<P> Selector<P> for First<P>
 where
     P: IterablePopulation<Individual: Clone>,
 {
-    type Population = P;
     type Output = [P::Individual; 1];
     type Error = FirstError;
 
-    fn select<R>(&self, population: &P, _: &mut R) -> Result<Self::Output, Self::Error>
+    fn select<Rng>(&self, population: &P, _: &mut Rng) -> Result<Self::Output, Self::Error>
     where
-        R: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         Ok([population.iter().next().ok_or(FirstError::Empty)?.clone()])
     }

--- a/packages/brace-ec/src/core/operator/selector/mutate.rs
+++ b/packages/brace-ec/src/core/operator/selector/mutate.rs
@@ -1,4 +1,3 @@
-use rand::Rng;
 use thiserror::Error;
 
 use crate::core::operator::mutator::Mutator;
@@ -18,22 +17,18 @@ impl<S, M> Mutate<S, M> {
     }
 }
 
-impl<S, M> Selector for Mutate<S, M>
+impl<P, S, M> Selector<P> for Mutate<S, M>
 where
-    S: Selector<Output: TryMap<Item = <S::Population as Population>::Individual>>,
-    M: Mutator<<S::Population as Population>::Individual>,
+    P: Population,
+    S: Selector<P, Output: TryMap<Item = P::Individual>>,
+    M: Mutator<P::Individual>,
 {
-    type Population = S::Population;
     type Output = S::Output;
     type Error = MutateError<S::Error, M::Error>;
 
-    fn select<R>(
-        &self,
-        population: &Self::Population,
-        rng: &mut R,
-    ) -> Result<Self::Output, Self::Error>
+    fn select<Rng>(&self, population: &P, rng: &mut Rng) -> Result<Self::Output, Self::Error>
     where
-        R: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         self.selector
             .select(population, rng)

--- a/packages/brace-ec/src/core/operator/selector/random.rs
+++ b/packages/brace-ec/src/core/operator/selector/random.rs
@@ -1,5 +1,4 @@
 use rand::seq::IteratorRandom;
-use rand::Rng;
 use thiserror::Error;
 
 use crate::core::population::IterablePopulation;
@@ -10,17 +9,16 @@ use super::Selector;
 #[derive(Clone, Copy, Debug)]
 pub struct Random<P: IterablePopulation>;
 
-impl<P> Selector for Random<P>
+impl<P> Selector<P> for Random<P>
 where
     P: IterablePopulation<Individual: Clone>,
 {
-    type Population = P;
     type Output = [P::Individual; 1];
     type Error = RandomError;
 
-    fn select<R>(&self, population: &P, rng: &mut R) -> Result<Self::Output, Self::Error>
+    fn select<Rng>(&self, population: &P, rng: &mut Rng) -> Result<Self::Output, Self::Error>
     where
-        R: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         Ok([population
             .iter()

--- a/packages/brace-ec/src/core/operator/selector/recombine.rs
+++ b/packages/brace-ec/src/core/operator/selector/recombine.rs
@@ -1,7 +1,7 @@
-use rand::Rng;
 use thiserror::Error;
 
 use crate::core::operator::recombinator::Recombinator;
+use crate::core::population::Population;
 
 use super::Selector;
 
@@ -19,22 +19,18 @@ impl<S, R> Recombine<S, R> {
     }
 }
 
-impl<S, R> Selector for Recombine<S, R>
+impl<P, S, R> Selector<P> for Recombine<S, R>
 where
-    S: Selector,
+    P: Population,
+    S: Selector<P>,
     R: Recombinator<S::Output>,
 {
-    type Population = S::Population;
     type Output = R::Output;
     type Error = RecombineError<S::Error, R::Error>;
 
-    fn select<G>(
-        &self,
-        population: &Self::Population,
-        rng: &mut G,
-    ) -> Result<Self::Output, Self::Error>
+    fn select<Rng>(&self, population: &P, rng: &mut Rng) -> Result<Self::Output, Self::Error>
     where
-        G: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         let parents = self
             .selector
@@ -59,26 +55,23 @@ pub enum RecombineError<S, R> {
 mod tests {
     use std::convert::Infallible;
 
-    use rand::Rng;
-
     use crate::core::operator::recombinator::sum::Sum;
     use crate::core::operator::selector::Selector;
     use crate::core::population::Population;
 
     struct LastTwo;
 
-    impl Selector for LastTwo {
-        type Population = [u8; 5];
+    impl Selector<[u8; 5]> for LastTwo {
         type Output = [u8; 2];
         type Error = Infallible;
 
-        fn select<R>(
+        fn select<Rng>(
             &self,
-            population: &Self::Population,
-            _: &mut R,
+            population: &[u8; 5],
+            _: &mut Rng,
         ) -> Result<Self::Output, Self::Error>
         where
-            R: Rng + ?Sized,
+            Rng: rand::Rng + ?Sized,
         {
             Ok([population[3], population[4]])
         }

--- a/packages/brace-ec/src/core/operator/selector/take.rs
+++ b/packages/brace-ec/src/core/operator/selector/take.rs
@@ -1,4 +1,3 @@
-use rand::Rng;
 use thiserror::Error;
 
 use crate::core::population::Population;
@@ -16,21 +15,17 @@ impl<S, const N: usize> Take<S, N> {
     }
 }
 
-impl<S, const N: usize> Selector for Take<S, N>
+impl<P, S, const N: usize> Selector<P> for Take<S, N>
 where
-    S: Selector<Output: IntoIterator<Item = <S::Population as Population>::Individual>>,
+    P: Population,
+    S: Selector<P, Output: IntoIterator<Item = P::Individual>>,
 {
-    type Population = S::Population;
-    type Output = [<S::Population as Population>::Individual; N];
+    type Output = [P::Individual; N];
     type Error = TakeError<S::Error>;
 
-    fn select<R>(
-        &self,
-        population: &Self::Population,
-        rng: &mut R,
-    ) -> Result<Self::Output, Self::Error>
+    fn select<Rng>(&self, population: &P, rng: &mut Rng) -> Result<Self::Output, Self::Error>
     where
-        R: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         let individuals = self
             .selector

--- a/packages/brace-ec/src/core/operator/selector/tournament.rs
+++ b/packages/brace-ec/src/core/operator/selector/tournament.rs
@@ -1,7 +1,6 @@
 use std::marker::PhantomData;
 
 use rand::seq::IteratorRandom;
-use rand::Rng;
 use thiserror::Error;
 
 use crate::core::fitness::Fitness;
@@ -30,21 +29,16 @@ where
     }
 }
 
-impl<P> Selector for Tournament<P>
+impl<P> Selector<P> for Tournament<P>
 where
     P: IterablePopulation<Individual: Clone + Fitness>,
 {
-    type Population = P;
     type Output = [P::Individual; 1];
     type Error = TournamentError;
 
-    fn select<R>(
-        &self,
-        population: &Self::Population,
-        rng: &mut R,
-    ) -> Result<Self::Output, Self::Error>
+    fn select<Rng>(&self, population: &P, rng: &mut Rng) -> Result<Self::Output, Self::Error>
     where
-        R: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         if self.size == 0 {
             return Err(TournamentError::Empty);

--- a/packages/brace-ec/src/core/operator/then.rs
+++ b/packages/brace-ec/src/core/operator/then.rs
@@ -1,4 +1,3 @@
-use rand::Rng;
 use thiserror::Error;
 
 use crate::core::individual::Individual;
@@ -20,22 +19,18 @@ impl<L, R> Then<L, R> {
     }
 }
 
-impl<L, R> Selector for Then<L, R>
+impl<P, L, R> Selector<P> for Then<L, R>
 where
-    L: Selector,
-    R: Selector<Population = L::Output>,
+    P: Population,
+    L: Selector<P>,
+    R: Selector<L::Output>,
 {
-    type Population = L::Population;
     type Output = R::Output;
     type Error = ThenError<L::Error, R::Error>;
 
-    fn select<G>(
-        &self,
-        population: &Self::Population,
-        rng: &mut G,
-    ) -> Result<Self::Output, Self::Error>
+    fn select<Rng>(&self, population: &P, rng: &mut Rng) -> Result<Self::Output, Self::Error>
     where
-        G: Rng + ?Sized,
+        Rng: rand::Rng + ?Sized,
     {
         let population = self.lhs.select(population, rng).map_err(ThenError::Left)?;
 
@@ -114,8 +109,6 @@ pub enum ThenError<L, R> {
 mod tests {
     use std::convert::Infallible;
 
-    use rand::Rng;
-
     use crate::core::individual::Individual;
     use crate::core::operator::evolver::select::Select;
     use crate::core::operator::evolver::Evolver;
@@ -129,18 +122,17 @@ mod tests {
 
     struct All;
 
-    impl Selector for All {
-        type Population = [i32; 5];
+    impl Selector<[i32; 5]> for All {
         type Output = [i32; 5];
         type Error = Infallible;
 
-        fn select<R>(
+        fn select<Rng>(
             &self,
-            population: &Self::Population,
-            _: &mut R,
+            population: &[i32; 5],
+            _: &mut Rng,
         ) -> Result<Self::Output, Self::Error>
         where
-            R: Rng + ?Sized,
+            Rng: rand::Rng + ?Sized,
         {
             Ok(*population)
         }

--- a/packages/brace-ec/src/core/population.rs
+++ b/packages/brace-ec/src/core/population.rs
@@ -17,7 +17,7 @@ pub trait Population {
 
     fn select<S>(&self, selector: S) -> Result<S::Output, S::Error>
     where
-        S: Selector<Population = Self>,
+        S: Selector<Self>,
     {
         selector.select(self, &mut thread_rng())
     }


### PR DESCRIPTION
This redesigns the `Selector` trait following the changes to `Scorer`, `Mutator` and `Recombinator`.

The `Selector` trait, like other operator traits, uses an associated type as the input rather than a generic. The intent behind this design was to limit the implementations of the trait to one per type to not break type inference. However, it is still possible to write multiple implementations and the use of an associated input greatly impacts the readability of trait bounds.

This change updates the `Selector` trait to replace the associated `Population` with a generic `P`. It also renames the generic `R` to `Rng` and tweaks the bound to use the fully qualified path. This ensures that it is consistent with the `Scorer`, `Mutator` and `Recombinator` traits.

This also adjusts the `Select` evolver to avoid an unconstrained `P` generic but that might change again when the `Evolver` trait is updated.