### PR TITLE
Redesign `Evolver` trait

### DIFF
--- a/packages/brace-ec/src/core/operator/evolver/select.rs
+++ b/packages/brace-ec/src/core/operator/evolver/select.rs
@@ -1,5 +1,3 @@
-use std::marker::PhantomData;
-
 use thiserror::Error;
 
 use crate::core::generation::Generation;
@@ -10,21 +8,17 @@ use crate::util::map::TryMap;
 use super::Evolver;
 
 #[derive(Clone, Debug, Default)]
-pub struct Select<P, S> {
+pub struct Select<S> {
     selector: S,
-    marker: PhantomData<fn() -> P>,
 }
 
-impl<P, S> Select<P, S> {
+impl<S> Select<S> {
     pub fn new(selector: S) -> Self {
-        Self {
-            selector,
-            marker: PhantomData,
-        }
+        Self { selector }
     }
 }
 
-impl<P, S> Evolver<(u64, P)> for Select<P, S>
+impl<P, S> Evolver<(u64, P)> for Select<S>
 where
     P: Population + Clone + TryMap<Item = P::Individual>,
     S: Selector<P, Output: IntoIterator<Item = P::Individual>>,


### PR DESCRIPTION
This redesigns the `Evolver` trait following the changes to `Scorer`, `Mutator`, `Recombinator` and `Selector`.

The `Evolver` trait, like other operator traits, uses an associated type as the input rather than a generic. The intent behind this design was to limit the implementations of the trait to one per type to not break type inference. However, it is still possible to write multiple implementations and the use of an associated input greatly impacts the readability of trait bounds.

This change updates the `Evolver` trait to replace the associated `Generation` with a generic `G`. It also updates the `evolve` method to take a generic `Rng` parameter. This ensures that it is consistent with the `Scorer`, `Mutator`, `Recombinator` and `Selector` traits.

The previous design relied on evolvers using their own random number generator but this meant that different adapters would potentially use different random number generators. The reason for not including this initially is that a future update might add parallel selection and it would not be possible to use a mutable random number generator input for parallel selectors.

This change resolves an issue with the `Inspect` operator adapter evolve test unintentionally calling `inspect` on the result and not the operator.

This also adjusts the `Select` evolver to restore the single generic which was changed when `Selector` was updated.