### PR TITLE
Add `Worst` selector

### DIFF
--- a/packages/brace-ec/src/core/operator/selector/mod.rs
+++ b/packages/brace-ec/src/core/operator/selector/mod.rs
@@ -6,6 +6,7 @@ pub mod random;
 pub mod recombine;
 pub mod take;
 pub mod tournament;
+pub mod worst;
 
 use crate::core::fitness::{Fitness, FitnessMut};
 use crate::core::population::Population;

--- a/packages/brace-ec/src/core/operator/selector/worst.rs
+++ b/packages/brace-ec/src/core/operator/selector/worst.rs
@@ -1,0 +1,72 @@
+use thiserror::Error;
+
+use crate::core::fitness::Fitness;
+use crate::core::population::{IterablePopulation, Population};
+
+use super::Selector;
+
+#[ghost::phantom]
+#[derive(Clone, Copy, Debug)]
+pub struct Worst<P: Population>;
+
+impl<P> Selector<P> for Worst<P>
+where
+    P: IterablePopulation<Individual: Clone + Fitness>,
+{
+    type Output = [P::Individual; 1];
+    type Error = WorstError;
+
+    fn select<Rng>(&self, population: &P, _: &mut Rng) -> Result<Self::Output, Self::Error>
+    where
+        Rng: rand::Rng + ?Sized,
+    {
+        Ok([population
+            .iter()
+            .min_by_key(|individual| individual.fitness())
+            .ok_or(WorstError::Empty)?
+            .clone()])
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum WorstError {
+    #[error("empty population")]
+    Empty,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cmp::Reverse;
+
+    use crate::core::individual::scored::Scored;
+    use crate::core::population::Population;
+
+    use super::Worst;
+
+    #[test]
+    fn test_select() {
+        let population = [0, 1, 2, 3, 4];
+        let individual = population.select(Worst).unwrap()[0];
+
+        assert_eq!(individual, 0);
+
+        let population = [Reverse(0), Reverse(1), Reverse(2), Reverse(3), Reverse(4)];
+        let individual = population.select(Worst).unwrap()[0];
+
+        assert_eq!(individual, Reverse(4));
+
+        let population = [Scored::new(0, 0), Scored::new(10, 10), Scored::new(20, 5)];
+        let individual = population.select(Worst).unwrap()[0];
+
+        assert_eq!(individual, Scored::new(0, 0));
+
+        let population = [
+            Reverse(Scored::new(30, 3)),
+            Reverse(Scored::new(10, 10)),
+            Reverse(Scored::new(20, 5)),
+        ];
+        let individual = population.select(Worst).unwrap()[0];
+
+        assert_eq!(individual, Reverse(Scored::new(10, 10)));
+    }
+}


### PR DESCRIPTION
This adds a new `Worst` selector which is opposite to the `Best` selector.

The project currently has a `Best` selector to get the best individual from a population. However, it may be necessary to also get the worst individual in a population. This is useful for situations where reversing the fitness score isn't possible and a lower score is required. The naming here might make better sense as `Highest` and `Lowest` but evolutionary computation typically uses the term *best* so this would be the opposite to that.

This change adds a new `Worst` selector that simply copies the implementation of `Best` and switches the call to `max_by_key` with `min_by_key`.