### PR TITLE
Add dyn-compatible operator traits

### DIFF
--- a/packages/brace-ec/src/core/operator/evolver/mod.rs
+++ b/packages/brace-ec/src/core/operator/evolver/mod.rs
@@ -61,3 +61,34 @@ where
         Inspect::new(self, inspector)
     }
 }
+
+pub trait DynEvolver<G, E = Box<dyn std::error::Error>>
+where
+    G: Generation,
+{
+    fn dyn_evolve(&self, generation: G, rng: &mut dyn rand::RngCore) -> Result<G, E>;
+}
+
+impl<G, E, T> DynEvolver<G, E> for T
+where
+    G: Generation,
+    T: Evolver<G, Error: Into<E>>,
+{
+    fn dyn_evolve(&self, generation: G, rng: &mut dyn rand::RngCore) -> Result<G, E> {
+        self.evolve(generation, rng).map_err(Into::into)
+    }
+}
+
+impl<G, E> Evolver<G> for Box<dyn DynEvolver<G, E>>
+where
+    G: Generation,
+{
+    type Error = E;
+
+    fn evolve<Rng>(&self, individual: G, mut rng: &mut Rng) -> Result<G, Self::Error>
+    where
+        Rng: rand::Rng + ?Sized,
+    {
+        (**self).dyn_evolve(individual, &mut rng)
+    }
+}

--- a/packages/brace-ec/src/core/operator/scorer/mod.rs
+++ b/packages/brace-ec/src/core/operator/scorer/mod.rs
@@ -13,3 +13,40 @@ where
     where
         Rng: rand::Rng + ?Sized;
 }
+
+pub trait DynScorer<I, S, E = Box<dyn std::error::Error>>
+where
+    I: Individual,
+    S: Ord,
+{
+    fn dyn_score(&self, individual: &I, rng: &mut dyn rand::RngCore) -> Result<S, E>;
+}
+
+impl<I, S, E, T> DynScorer<I, S, E> for T
+where
+    I: Individual,
+    S: Ord,
+    T: Scorer<I, Score: Into<S>, Error: Into<E>>,
+{
+    fn dyn_score(&self, individual: &I, rng: &mut dyn rand::RngCore) -> Result<S, E> {
+        self.score(individual, rng)
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+}
+
+impl<I, S, E> Scorer<I> for Box<dyn DynScorer<I, S, E>>
+where
+    I: Individual,
+    S: Ord,
+{
+    type Score = S;
+    type Error = E;
+
+    fn score<Rng>(&self, individual: &I, mut rng: &mut Rng) -> Result<Self::Score, Self::Error>
+    where
+        Rng: rand::Rng + ?Sized,
+    {
+        (**self).dyn_score(individual, &mut rng)
+    }
+}


### PR DESCRIPTION
This adds dyn-compatible operator traits for selection, mutation, recombination, evolution and scoring.

The various operator traits are not dyn-compatible (previously known as object safe) as they include a generic `Rng` on the operator method. This means that it is not possible to create a `Box<dyn Selector>` or equivalent for other operators. For this reason the `Sized` bound was added to the traits to avoid needing to specify that on the methods. However, it is possible to use these operators in a dyn-compatible way by introducing new traits.

This change adds the `DynSelector`, `DynMutator`, `DynRecombinator`, `DynEvolver` and `DynScorer` traits with blanket implementations for types implementing the non-dyn-compatible variant of the trait. This is fortunately possible because the `RngCore` trait is implemented on mutable references and `Rng` is implemented on anything that implements `RngCore`. This adds the minor overhead of dynamic dispatch but is not the primary way of interacting with the operators so it shouldn't cause any issues.

The change also implements the operator traits for boxed trait objects but this should be expanded in the future to cover other trait objects and variants with `Send + Sync` bounds once parallel operators are introduced.