### PR TITLE
Update `Invert` mutator to invert associated genome

### DIFF
--- a/packages/brace-ec/src/core/operator/mutator/invert.rs
+++ b/packages/brace-ec/src/core/operator/mutator/invert.rs
@@ -11,7 +11,7 @@ pub struct Invert<I: Individual>;
 
 impl<I> Mutator<I> for Invert<I>
 where
-    I: Individual + Not<Output = I>,
+    I: Individual<Genome: Not<Output = I::Genome> + Clone> + From<I::Genome>,
 {
     type Error = Infallible;
 
@@ -19,7 +19,7 @@ where
     where
         Rng: rand::Rng + ?Sized,
     {
-        Ok(individual.not())
+        Ok(individual.genome().clone().not().into())
     }
 }
 
@@ -27,6 +27,7 @@ where
 mod tests {
     use rand::thread_rng;
 
+    use crate::core::individual::scored::Scored;
     use crate::core::operator::mutator::Mutator;
 
     use super::Invert;
@@ -37,8 +38,10 @@ mod tests {
 
         let a = Invert.mutate(true, &mut rng).unwrap();
         let b = Invert.mutate(false, &mut rng).unwrap();
+        let c = Invert.mutate(Scored::new(true, 0), &mut rng).unwrap();
 
         assert!(!a);
         assert!(b);
+        assert_eq!(c, Scored::new(false, 0));
     }
 }


### PR DESCRIPTION
This updates the `Invert` mutator to invert the associated genome instead of the individual.

This change is a follow-up to #36 and the first part of #37 that updates the `Invert` mutator to invert the associated genome instead of the individual itself. This requires the genome to implement both `Not` and `Clone` and requires the individual to be implement `From` for the genome.

The implementation is less restrictive than before as covered by the test that used the `Scored` adapter but is perhaps not ideal because it loses any other data associated with the original individual. The upside is that this would reset the score of a `Scored` individual.