### PR TITLE
Update `Sum` recombinator to sum associated genome

### DIFF
--- a/packages/brace-ec/src/util/sum.rs
+++ b/packages/brace-ec/src/util/sum.rs
@@ -1,18 +1,31 @@
 use num_traits::{CheckedAdd, Zero};
 
-use super::iter::Iterable;
-
-pub trait CheckedSum<T> {
-    fn checked_sum(&self) -> Option<T>;
+pub trait CheckedSum<T = Self>: Sized {
+    fn checked_sum<I>(iter: I) -> Option<Self>
+    where
+        I: Iterator<Item = T>;
 }
 
-impl<T, I> CheckedSum<T> for I
+impl<T> CheckedSum<T> for T
 where
     T: CheckedAdd + Zero,
-    I: Iterable<Item = T>,
 {
-    fn checked_sum(&self) -> Option<T> {
-        self.iter()
-            .try_fold(T::zero(), |acc, value| acc.checked_add(value))
+    fn checked_sum<I>(mut iter: I) -> Option<Self>
+    where
+        I: Iterator<Item = T>,
+    {
+        iter.try_fold(T::zero(), |acc, value| acc.checked_add(&value))
+    }
+}
+
+impl<'a, T> CheckedSum<&'a T> for T
+where
+    T: CheckedAdd + Zero,
+{
+    fn checked_sum<I>(mut iter: I) -> Option<Self>
+    where
+        I: Iterator<Item = &'a T>,
+    {
+        iter.try_fold(T::zero(), |acc, value| acc.checked_add(value))
     }
 }


### PR DESCRIPTION
Closes #37.

This updates the `Sum` recombinator to sum the associated genome instead of the individual.

This is a follow-up to #36 and #58 that updates the `Sum` recombinator to sum the associated genome instead of the individual itself. This requires the genome to implement an updated version of `CheckedSum` and for the individual to implement `From` for the genome.

The implementation is less restrictive than before as covered by the test that uses the `Scored` adapter but is perhaps not ideal because it loses any other data associated with the original individual. The upside is that this would reset the score of a `Scored` individual. The alternative would be to update the genome of the first individual but that would require at least one individual and the implementation currently supports none so a new error variant would be required.

The change includes an update to the `CheckedSum` utility trait that is now implemented on the summed type and takes an iterator instead of being implemented on an `Iterable`. This includes an implementation for owned items and another for references as the `CheckedAdd` trait only works on references, unlike the standard `Add` trait.