### PR TITLE
Add `Average` recombinator

### DIFF
--- a/packages/brace-ec/src/core/operator/recombinator/average.rs
+++ b/packages/brace-ec/src/core/operator/recombinator/average.rs
@@ -1,0 +1,82 @@
+use num_traits::{CheckedDiv, FromPrimitive};
+use thiserror::Error;
+
+use crate::core::individual::Individual;
+use crate::core::population::IterablePopulation;
+use crate::util::sum::CheckedSum;
+
+use super::Recombinator;
+
+#[ghost::phantom]
+#[derive(Clone, Copy, Debug)]
+pub struct Average<P: IterablePopulation>;
+
+impl<P, G> Recombinator<P> for Average<P>
+where
+    P: IterablePopulation<Individual: Individual<Genome = G> + From<G>>,
+    G: for<'a> CheckedSum<&'a G> + CheckedDiv + FromPrimitive,
+{
+    type Output = [P::Individual; 1];
+    type Error = AverageError;
+
+    fn recombine<Rng>(&self, parents: P, _: &mut Rng) -> Result<Self::Output, Self::Error>
+    where
+        Rng: rand::Rng + ?Sized,
+    {
+        if parents.len() == 0 {
+            return Err(AverageError::Empty);
+        }
+
+        let Some(len) = G::from_usize(parents.len()) else {
+            return Err(AverageError::Unrepresentable);
+        };
+
+        let genome = G::checked_sum(parents.iter().map(Individual::genome))
+            .ok_or(AverageError::Wrap)?
+            .checked_div(&len)
+            .ok_or(AverageError::Wrap)?;
+
+        Ok([genome.into()])
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum AverageError {
+    #[error("summation would wrap")]
+    Wrap,
+    #[error("population length could not be represented as genome")]
+    Unrepresentable,
+    #[error("empty population")]
+    Empty,
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::thread_rng;
+
+    use crate::core::individual::scored::Scored;
+    use crate::core::operator::recombinator::Recombinator;
+
+    use super::{Average, AverageError};
+
+    #[test]
+    fn test_recombine() {
+        let mut rng = thread_rng();
+
+        let a = Average.recombine([0, 0], &mut rng);
+        let b = Average.recombine([1, 1, 1], &mut rng);
+        let c = Average.recombine([1, i32::MAX], &mut rng);
+        let d = Average.recombine([Scored::new(3, 0), Scored::new(4, 0)], &mut rng);
+        let e = Average.recombine([1, 2, 3, 4, 5], &mut rng);
+        let f = Average.recombine([100, 200, 300], &mut rng);
+        let g = Average.recombine([100, 200, 300, 450], &mut rng);
+
+        assert_eq!(a, Ok([0]));
+        assert_eq!(b, Ok([1]));
+        assert_eq!(c, Err(AverageError::Wrap));
+        assert_eq!(d, Ok([Scored::new(3, 0)]));
+        assert_eq!(e, Ok([3]));
+        assert_eq!(f, Ok([200]));
+        assert_eq!(g, Ok([262]));
+    }
+}

--- a/packages/brace-ec/src/core/operator/recombinator/mod.rs
+++ b/packages/brace-ec/src/core/operator/recombinator/mod.rs
@@ -1,3 +1,4 @@
+pub mod average;
 pub mod sum;
 
 use crate::core::fitness::{Fitness, FitnessMut};


### PR DESCRIPTION
This adds a new `Average` recombinator similar to the `Sum` recombinator.

The project currently has very few recombinators to create simple examples. Outside of the crossovers there is only the `Sum` recombinator. Implementing an `Average` recombinator should be fairly simple as half of the logic is already implemented already by `Sum`.

This change introduces a new `Average` operator based on the `Sum` operator with the addition of the `CheckedDiv` and `FromPrimitive` trait bounds. The latter is used to convert the population length to the genome for the division. This necessitated the addition of an unrepresentable error variant. Another option would have been to use the `One` trait and sum ones while also summing the genomes but that might optimise poorly.