### PR TITLE
Add example demonstrating `Average` recombinator

### DIFF
--- a/packages/brace-ec/examples/average.rs
+++ b/packages/brace-ec/examples/average.rs
@@ -1,0 +1,52 @@
+use brace_ec::core::generation::Generation;
+use brace_ec::core::operator::evolver::select::Select;
+use brace_ec::core::operator::evolver::Evolver;
+use brace_ec::core::operator::mutator::noise::Noise;
+use brace_ec::core::operator::mutator::Mutator;
+use brace_ec::core::operator::recombinator::average::Average;
+use brace_ec::core::operator::selector::best::Best;
+use brace_ec::core::operator::selector::tournament::Tournament;
+use brace_ec::core::operator::selector::Selector;
+use brace_ec::core::population::Population;
+
+pub fn main() {
+    let generation = (0, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    let selector = Tournament::binary()
+        .mutate(Noise(1..10).rate(0.5))
+        .repeat(2)
+        .recombine(Average)
+        .mutate(Noise(1..10).rate(0.5));
+
+    print_generation(&generation);
+
+    Select::new(selector)
+        .repeat(10)
+        .inspect(print_generation)
+        .repeat(10)
+        .inspect(print_best)
+        .evolve(generation, &mut rand::thread_rng())
+        .unwrap();
+}
+
+fn print_best(generation: &(u64, [i64; 10])) {
+    let best = generation.population().select(Best).unwrap();
+
+    println!("Best: {:>4}", best[0]);
+}
+
+fn print_generation(generation: &(u64, [i64; 10])) {
+    println!(
+        "{:>4}: {:>4} {:>4} {:>4} {:>4} {:>4} {:>4} {:>4} {:>4} {:>4} {:>4}",
+        generation.id(),
+        generation.population()[0],
+        generation.population()[1],
+        generation.population()[2],
+        generation.population()[3],
+        generation.population()[4],
+        generation.population()[5],
+        generation.population()[6],
+        generation.population()[7],
+        generation.population()[8],
+        generation.population()[9],
+    )
+}


### PR DESCRIPTION
This adds the `average` example to demonstrate the use of the `Average` recombinator together with the `Tournament` selector and `Noise` mutator.

The `Average` recombinator was added in #60 as a simple recombinator for numeric individual genomes with the primary purpose of using as an example for the project. Examples not only show how the project can be used but also act as a compile-time check to ensure that any changes to the operator design still works as intended. The tests do not always cover the types of composition that might be found in a real evolutionary computation program but examples should be closer.

This change introduces a new example called `average` that shows how the system evolves a population using the `Average` recombinator, `Tournament` selector and `Noise` mutator. This also makes use of the `Rate` mutator as well as the `Repeat` and `Inspect` evolvers. The example does not include any comments explaining how or what it is doing as it should hopefully be self-explanatory.