### PR TITLE
Add `Fill` selector adapter

### DIFF
--- a/packages/brace-ec/src/core/operator/selector/fill.rs
+++ b/packages/brace-ec/src/core/operator/selector/fill.rs
@@ -1,0 +1,84 @@
+use thiserror::Error;
+
+use crate::core::population::Population;
+use crate::util::map::TryMap;
+
+use super::Selector;
+
+#[derive(Clone, Debug, Default)]
+pub struct Fill<S> {
+    selector: S,
+}
+
+impl<S> Fill<S> {
+    pub fn new(selector: S) -> Self {
+        Self { selector }
+    }
+}
+
+impl<P, S> Selector<P> for Fill<S>
+where
+    P: Population + Clone + TryMap<Item = P::Individual>,
+    S: Selector<P, Output: IntoIterator<Item = P::Individual>>,
+{
+    type Output = P;
+    type Error = FillError<S::Error>;
+
+    fn select<Rng>(&self, population: &P, rng: &mut Rng) -> Result<Self::Output, Self::Error>
+    where
+        Rng: rand::Rng + ?Sized,
+    {
+        let mut selection = self
+            .selector
+            .select(population, rng)
+            .map_err(FillError::Select)?
+            .into_iter();
+
+        let population = population.clone().try_map(|_| match selection.next() {
+            Some(individual) => Ok(individual),
+            None => {
+                selection = self
+                    .selector
+                    .select(population, rng)
+                    .map_err(FillError::Select)?
+                    .into_iter();
+
+                match selection.next() {
+                    Some(individual) => Ok(individual),
+                    None => Err(FillError::NotEnough),
+                }
+            }
+        })?;
+
+        Ok(population)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum FillError<S> {
+    #[error("unable to fill population from selector")]
+    NotEnough,
+    #[error(transparent)]
+    Select(S),
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::operator::selector::best::Best;
+    use crate::core::operator::selector::worst::Worst;
+    use crate::core::operator::selector::Selector;
+    use crate::core::population::Population;
+
+    #[test]
+    fn test_select() {
+        let population = [1, 2, 3, 4, 5];
+
+        let a = population.select(Best.fill()).unwrap();
+        let b = population.select(Worst.fill()).unwrap();
+        let c = population.select(Best.and(Worst).fill()).unwrap();
+
+        assert_eq!(a, [5; 5]);
+        assert_eq!(b, [1; 5]);
+        assert_eq!(c, [5, 1, 5, 1, 5]);
+    }
+}

--- a/packages/brace-ec/src/core/operator/selector/mod.rs
+++ b/packages/brace-ec/src/core/operator/selector/mod.rs
@@ -1,5 +1,6 @@
 pub mod and;
 pub mod best;
+pub mod fill;
 pub mod first;
 pub mod mutate;
 pub mod random;
@@ -12,6 +13,7 @@ use crate::core::fitness::{Fitness, FitnessMut};
 use crate::core::population::Population;
 
 use self::and::And;
+use self::fill::Fill;
 use self::mutate::Mutate;
 use self::recombine::Recombine;
 use self::take::Take;
@@ -78,6 +80,10 @@ where
         S: Selector<Self::Output>,
     {
         Then::new(self, selector)
+    }
+
+    fn fill(self) -> Fill<Self> {
+        Fill::new(self)
     }
 
     fn take<const N: usize>(self) -> Take<Self, N>


### PR DESCRIPTION
This adds a new `Fill` selector adapter that fills the population with the output of the inner selector.

The implementation of the `Select` evolver uses a selector that is repeatedly called to fill the population with new individuals. This is not the most performant as it clones the population to create a new population of the required size. This
logic is itself a selector so it can be extracted out into its own type.

This change introduces the `Fill` selector adapter using the logic in the `Select` evolver to repeatedly call `select` to fill the entire population with new individuals. This includes a utility method on the `Selector` trait to easily adapt any selector to fill the population. It also updates the implementation of the `Select` evolver to use the new adapter. This maps the error type so that the API of the evolver is separate such that it can be updated to a different implementation at a later date.

The downside to this selector is that repeatedly chaining it can be problematic due to the repeated clone. This is unlikely to be the case but it is possible that a fill will be passed to the evolver which contains its own fill. The implementation of the `Select` evolver could be updated to require the population to be filled externally but that may not be intuitive. Perhaps the best option would be to introduce a new trait based on `TryFromIterator` that would skip subsequent clones if the output of the inner selector was already the correct type and length.