### PR TITLE
Add support for unsized populations in selectors

### DIFF
--- a/packages/brace-ec/src/core/operator/inspect.rs
+++ b/packages/brace-ec/src/core/operator/inspect.rs
@@ -23,7 +23,7 @@ impl<T, F> Inspect<T, F> {
 
 impl<P, T, F> Selector<P> for Inspect<T, F>
 where
-    P: Population,
+    P: Population + ?Sized,
     T: Selector<P>,
     F: Fn(&T::Output),
 {

--- a/packages/brace-ec/src/core/operator/repeat.rs
+++ b/packages/brace-ec/src/core/operator/repeat.rs
@@ -20,7 +20,7 @@ impl<T> Repeat<T> {
 
 impl<P, T> Selector<P> for Repeat<T>
 where
-    P: Population,
+    P: Population + ?Sized,
     T: Selector<P, Output: IntoIterator<Item = P::Individual>>,
 {
     type Output = Vec<P::Individual>;

--- a/packages/brace-ec/src/core/operator/score.rs
+++ b/packages/brace-ec/src/core/operator/score.rs
@@ -25,7 +25,7 @@ impl<T, S> Score<T, S> {
 
 impl<P, T, S, I> Selector<P> for Score<T, S>
 where
-    P: Population<Individual = I>,
+    P: Population<Individual = I> + ?Sized,
     T: Selector<P, Output: TryMap<Item = I>>,
     S: Scorer<I, Score = I::Value>,
     I: FitnessMut,

--- a/packages/brace-ec/src/core/operator/selector/and.rs
+++ b/packages/brace-ec/src/core/operator/selector/and.rs
@@ -17,7 +17,7 @@ impl<L, R> And<L, R> {
 
 impl<P, L, R> Selector<P> for And<L, R>
 where
-    P: Population,
+    P: Population + ?Sized,
     L: Selector<P, Output: IntoIterator<Item = P::Individual>>,
     R: Selector<P, Output: IntoIterator<Item = P::Individual>>,
 {

--- a/packages/brace-ec/src/core/operator/selector/best.rs
+++ b/packages/brace-ec/src/core/operator/selector/best.rs
@@ -7,11 +7,11 @@ use super::Selector;
 
 #[ghost::phantom]
 #[derive(Clone, Copy, Debug)]
-pub struct Best<P: Population>;
+pub struct Best<P: Population + ?Sized>;
 
 impl<P> Selector<P> for Best<P>
 where
-    P: IterablePopulation<Individual: Clone + Fitness>,
+    P: IterablePopulation<Individual: Clone + Fitness> + ?Sized,
 {
     type Output = [P::Individual; 1];
     type Error = BestError;

--- a/packages/brace-ec/src/core/operator/selector/first.rs
+++ b/packages/brace-ec/src/core/operator/selector/first.rs
@@ -6,11 +6,11 @@ use super::Selector;
 
 #[ghost::phantom]
 #[derive(Clone, Copy, Debug)]
-pub struct First<P: IterablePopulation>;
+pub struct First<P: IterablePopulation + ?Sized>;
 
 impl<P> Selector<P> for First<P>
 where
-    P: IterablePopulation<Individual: Clone>,
+    P: IterablePopulation<Individual: Clone> + ?Sized,
 {
     type Output = [P::Individual; 1];
     type Error = FirstError;

--- a/packages/brace-ec/src/core/operator/selector/mod.rs
+++ b/packages/brace-ec/src/core/operator/selector/mod.rs
@@ -111,7 +111,7 @@ where
 
 pub trait DynSelector<P, O = Vec<<P as Population>::Individual>, E = Box<dyn std::error::Error>>
 where
-    P: Population,
+    P: Population + ?Sized,
     O: Population<Individual = P::Individual>,
 {
     fn dyn_select(&self, population: &P, rng: &mut dyn rand::RngCore) -> Result<O, E>;
@@ -119,7 +119,7 @@ where
 
 impl<P, O, E, T> DynSelector<P, O, E> for T
 where
-    P: Population,
+    P: Population + ?Sized,
     O: Population<Individual = P::Individual>,
     T: Selector<P, Output: Into<O>, Error: Into<E>>,
 {
@@ -132,7 +132,7 @@ where
 
 impl<P, O, E> Selector<P> for Box<dyn DynSelector<P, O, E>>
 where
-    P: Population,
+    P: Population + ?Sized,
     O: Population<Individual = P::Individual>,
 {
     type Output = O;

--- a/packages/brace-ec/src/core/operator/selector/mutate.rs
+++ b/packages/brace-ec/src/core/operator/selector/mutate.rs
@@ -19,7 +19,7 @@ impl<S, M> Mutate<S, M> {
 
 impl<P, S, M> Selector<P> for Mutate<S, M>
 where
-    P: Population,
+    P: Population + ?Sized,
     S: Selector<P, Output: TryMap<Item = P::Individual>>,
     M: Mutator<P::Individual>,
 {

--- a/packages/brace-ec/src/core/operator/selector/random.rs
+++ b/packages/brace-ec/src/core/operator/selector/random.rs
@@ -7,11 +7,11 @@ use super::Selector;
 
 #[ghost::phantom]
 #[derive(Clone, Copy, Debug)]
-pub struct Random<P: IterablePopulation>;
+pub struct Random<P: IterablePopulation + ?Sized>;
 
 impl<P> Selector<P> for Random<P>
 where
-    P: IterablePopulation<Individual: Clone>,
+    P: IterablePopulation<Individual: Clone> + ?Sized,
 {
     type Output = [P::Individual; 1];
     type Error = RandomError;

--- a/packages/brace-ec/src/core/operator/selector/recombine.rs
+++ b/packages/brace-ec/src/core/operator/selector/recombine.rs
@@ -21,7 +21,7 @@ impl<S, R> Recombine<S, R> {
 
 impl<P, S, R> Selector<P> for Recombine<S, R>
 where
-    P: Population,
+    P: Population + ?Sized,
     S: Selector<P>,
     R: Recombinator<S::Output>,
 {

--- a/packages/brace-ec/src/core/operator/selector/take.rs
+++ b/packages/brace-ec/src/core/operator/selector/take.rs
@@ -17,7 +17,7 @@ impl<S, const N: usize> Take<S, N> {
 
 impl<P, S, const N: usize> Selector<P> for Take<S, N>
 where
-    P: Population,
+    P: Population + ?Sized,
     S: Selector<P, Output: IntoIterator<Item = P::Individual>>,
 {
     type Output = [P::Individual; N];

--- a/packages/brace-ec/src/core/operator/selector/tournament.rs
+++ b/packages/brace-ec/src/core/operator/selector/tournament.rs
@@ -8,14 +8,14 @@ use crate::core::population::{IterablePopulation, Population};
 
 use super::Selector;
 
-pub struct Tournament<P: Population> {
+pub struct Tournament<P: Population + ?Sized> {
     size: usize,
     marker: PhantomData<fn() -> P>,
 }
 
 impl<P> Tournament<P>
 where
-    P: Population,
+    P: Population + ?Sized,
 {
     pub fn new(size: usize) -> Self {
         Self {
@@ -31,7 +31,7 @@ where
 
 impl<P> Selector<P> for Tournament<P>
 where
-    P: IterablePopulation<Individual: Clone + Fitness>,
+    P: IterablePopulation<Individual: Clone + Fitness> + ?Sized,
 {
     type Output = [P::Individual; 1];
     type Error = TournamentError;

--- a/packages/brace-ec/src/core/operator/selector/worst.rs
+++ b/packages/brace-ec/src/core/operator/selector/worst.rs
@@ -7,11 +7,11 @@ use super::Selector;
 
 #[ghost::phantom]
 #[derive(Clone, Copy, Debug)]
-pub struct Worst<P: Population>;
+pub struct Worst<P: Population + ?Sized>;
 
 impl<P> Selector<P> for Worst<P>
 where
-    P: IterablePopulation<Individual: Clone + Fitness>,
+    P: IterablePopulation<Individual: Clone + Fitness> + ?Sized,
 {
     type Output = [P::Individual; 1];
     type Error = WorstError;

--- a/packages/brace-ec/src/core/operator/then.rs
+++ b/packages/brace-ec/src/core/operator/then.rs
@@ -22,7 +22,7 @@ impl<L, R> Then<L, R> {
 
 impl<P, L, R> Selector<P> for Then<L, R>
 where
-    P: Population,
+    P: Population + ?Sized,
     L: Selector<P>,
     R: Selector<L::Output>,
 {

--- a/packages/brace-ec/src/core/operator/weighted.rs
+++ b/packages/brace-ec/src/core/operator/weighted.rs
@@ -21,7 +21,7 @@ where
 
 impl<P, O> Weighted<dyn DynSelector<P, O>>
 where
-    P: Population,
+    P: Population + ?Sized,
     O: Population<Individual = P::Individual>,
 {
     pub fn selector<S>(selector: S, weight: u64) -> Self

--- a/packages/brace-ec/src/core/population.rs
+++ b/packages/brace-ec/src/core/population.rs
@@ -31,6 +31,17 @@ pub trait Population {
     }
 }
 
+impl<T> Population for [T]
+where
+    T: Individual,
+{
+    type Individual = T;
+
+    fn len(&self) -> usize {
+        self.len()
+    }
+}
+
 impl<T, const N: usize> Population for [T; N]
 where
     T: Individual,
@@ -69,7 +80,7 @@ where
 
 pub trait IterablePopulation: Population + Iterable<Item = Self::Individual> {}
 
-impl<T> IterablePopulation for T where T: Population + Iterable<Item = Self::Individual> {}
+impl<T> IterablePopulation for T where T: Population + Iterable<Item = Self::Individual> + ?Sized {}
 
 #[cfg(test)]
 mod tests {

--- a/packages/brace-ec/src/util/iter.rs
+++ b/packages/brace-ec/src/util/iter.rs
@@ -12,6 +12,19 @@ pub trait Iterable {
     fn iter(&self) -> Self::Iter<'_>;
 }
 
+impl<T> Iterable for [T] {
+    type Item = T;
+
+    type Iter<'a>
+        = std::slice::Iter<'a, T>
+    where
+        Self: 'a;
+
+    fn iter(&self) -> Self::Iter<'_> {
+        self.iter()
+    }
+}
+
 impl<const N: usize, T> Iterable for [T; N] {
     type Item = T;
 
@@ -57,6 +70,17 @@ pub trait IterableMut: Iterable {
         Self: 'a;
 
     fn iter_mut(&mut self) -> Self::IterMut<'_>;
+}
+
+impl<T> IterableMut for [T] {
+    type IterMut<'a>
+        = std::slice::IterMut<'a, T>
+    where
+        T: 'a;
+
+    fn iter_mut(&mut self) -> Self::IterMut<'_> {
+        self.iter_mut()
+    }
 }
 
 impl<const N: usize, T> IterableMut for [T; N] {


### PR DESCRIPTION
This adds support for using unsized populations in selectors.

The current implementation of the `Selector` trait requires that the input population has a known size. However, the trait takes a reference to the population so there is no reason that it cannot support dynamically sized types. In particular it would be useful to support slices in addition to arrays and vectors.

This change updates the `Selector` trait and each of the compatible selectors to add a `?Sized` bound on the input population. It also implements the `Population`, `Iterable`, and `IterableMut` traits for slices and updates the `IterablePopulation` trait implementation to also add the `?Sized` bound.

The `DynSelector` trait has also been updated so that the `Weighted` selector supports unsized types. However, the `Fill` selector added in #64 is not compatible because neither `Clone` nor `TryMap` would work with dynamically sized types.