### PR TITLE
Add `Windows` selector adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,7 @@ version = "0.0.0"
 dependencies = [
  "array-util",
  "ghost",
+ "itertools 0.14.0",
  "num-traits",
  "ordered-float",
  "rand",
@@ -267,6 +268,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,7 +447,7 @@ dependencies = [
  "crossterm",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.13.0",
  "lru",
  "paste",
  "strum",
@@ -605,7 +615,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
- "itertools",
+ "itertools 0.13.0",
  "unicode-segmentation",
  "unicode-width 0.1.14",
 ]

--- a/packages/brace-ec/Cargo.toml
+++ b/packages/brace-ec/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 [dependencies]
 array-util = "1.0.2"
 ghost = "0.1.18"
+itertools = "0.14.0"
 num-traits = "0.2.19"
 ordered-float = "4.6.0"
 rand = "0.8.5"

--- a/packages/brace-ec/src/core/operator/selector/best.rs
+++ b/packages/brace-ec/src/core/operator/selector/best.rs
@@ -28,7 +28,7 @@ where
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq, Eq)]
 pub enum BestError {
     #[error("empty population")]
     Empty,

--- a/packages/brace-ec/src/core/operator/selector/mod.rs
+++ b/packages/brace-ec/src/core/operator/selector/mod.rs
@@ -7,6 +7,7 @@ pub mod random;
 pub mod recombine;
 pub mod take;
 pub mod tournament;
+pub mod windows;
 pub mod worst;
 
 use crate::core::fitness::{Fitness, FitnessMut};
@@ -17,6 +18,7 @@ use self::fill::Fill;
 use self::mutate::Mutate;
 use self::recombine::Recombine;
 use self::take::Take;
+use self::windows::Windows;
 
 use super::inspect::Inspect;
 use super::mutator::Mutator;
@@ -84,6 +86,14 @@ where
 
     fn fill(self) -> Fill<Self> {
         Fill::new(self)
+    }
+
+    fn windows<T>(self, count: usize) -> Windows<Self, T>
+    where
+        T: AsRef<[P::Individual]> + ?Sized,
+        Self: Selector<[P::Individual]>,
+    {
+        Windows::new(self, count)
     }
 
     fn take<const N: usize>(self) -> Take<Self, N>

--- a/packages/brace-ec/src/core/operator/selector/windows.rs
+++ b/packages/brace-ec/src/core/operator/selector/windows.rs
@@ -1,0 +1,138 @@
+use std::marker::PhantomData;
+
+use itertools::Itertools;
+use thiserror::Error;
+
+use crate::core::individual::Individual;
+use crate::core::population::Population;
+
+use super::Selector;
+
+pub struct Windows<S, P>
+where
+    P: ?Sized,
+{
+    selector: S,
+    size: usize,
+    marker: PhantomData<fn() -> P>,
+}
+
+impl<S, P> Windows<S, P>
+where
+    P: ?Sized,
+{
+    pub fn new(selector: S, size: usize) -> Self {
+        Self {
+            selector,
+            size,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<P, S, T> Selector<P> for Windows<S, P>
+where
+    P: Population<Individual = T> + AsRef<[T]> + ?Sized,
+    S: Selector<[T], Output: IntoIterator<Item = T>>,
+    T: Individual,
+{
+    type Output = Vec<T>;
+    type Error = WindowsError<S::Error>;
+
+    fn select<Rng>(&self, population: &P, rng: &mut Rng) -> Result<Self::Output, Self::Error>
+    where
+        Rng: rand::Rng + ?Sized,
+    {
+        if self.size == 0 {
+            return Err(WindowsError::Empty);
+        }
+
+        if population.len() < self.size {
+            return Err(WindowsError::TooLarge);
+        }
+
+        population
+            .as_ref()
+            .windows(self.size)
+            .map(|window| self.selector.select(window, rng))
+            .flatten_ok()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(WindowsError::Select)
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum WindowsError<S> {
+    #[error(transparent)]
+    Select(S),
+    #[error("window size is greater than population size")]
+    TooLarge,
+    #[error("window is empty")]
+    Empty,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::operator::mutator::add::Add;
+    use crate::core::operator::recombinator::sum::Sum;
+    use crate::core::operator::selector::best::Best;
+    use crate::core::operator::selector::worst::Worst;
+    use crate::core::operator::selector::Selector;
+    use crate::core::population::Population;
+
+    use super::{Windows, WindowsError};
+
+    #[test]
+    fn test_select() {
+        let population = [1, 2, 3, 4, 5];
+
+        let a = population
+            .select(Windows::new(Best, 2).mutate(Add(1)))
+            .unwrap();
+        let b = population
+            .select(Windows::new(Best, 3).mutate(Add(1)))
+            .unwrap();
+        let c = population
+            .select(Windows::new(Best, 4).mutate(Add(1)))
+            .unwrap();
+        let d = population
+            .select(Windows::new(Best, 5).mutate(Add(1)))
+            .unwrap();
+        let e = population
+            .select(Windows::new(Worst, 2).mutate(Add(1)))
+            .unwrap();
+        let f = population
+            .select(Windows::new(Best.and(Worst), 2).mutate(Add(1)))
+            .unwrap();
+        let g = population
+            .select(Windows::new(Best.and(Worst), 4).mutate(Add(1)))
+            .unwrap();
+        let h = population
+            .select(Windows::new(Best.and(Worst).recombine(Sum), 4).mutate(Add(1)))
+            .unwrap();
+        let i = population.select(Windows::new(Best, 0));
+        let j = population.select(Windows::new(Best, 6));
+
+        assert_eq!(a, [3, 4, 5, 6]);
+        assert_eq!(b, [4, 5, 6]);
+        assert_eq!(c, [5, 6]);
+        assert_eq!(d, [6]);
+        assert_eq!(e, [2, 3, 4, 5]);
+        assert_eq!(f, [3, 2, 4, 3, 5, 4, 6, 5]);
+        assert_eq!(g, [5, 2, 6, 3]);
+        assert_eq!(h, [6, 8]);
+        assert_eq!(i, Err(WindowsError::Empty));
+        assert_eq!(j, Err(WindowsError::TooLarge));
+    }
+
+    #[test]
+    fn test_populations() {
+        let a = [1, 2, 3, 4].select(Best.windows(1)).unwrap();
+        let b = vec![1, 2, 3, 4].select(Best.windows(1)).unwrap();
+        let c = [1, 2, 3, 4].as_slice().select(Best.windows(1)).unwrap();
+
+        assert_eq!(a, [1, 2, 3, 4]);
+        assert_eq!(b, [1, 2, 3, 4]);
+        assert_eq!(c, [1, 2, 3, 4]);
+    }
+}


### PR DESCRIPTION
This adds a new `Windows` selector adapter to select from population windows of the given size.

The design of the `Selector` operator allows for interesting adapters that enable users to create powerful selectors through composition. This is much like the `Iterator` trait in the standard library and there is plenty of inspiration that can be taken from iterators and applied in this project. For example, the `windows` method on slices returns a `Windows` iterator that returns overlapping segments of a slice.

This change introduces a new `Windows` selector adapter that takes another selector of slices and repeatedly calls it over the windows of the specified size. This supports arrays, vectors and slices by including an additional generic `P` using `PhantomData` that should be inferred during normal usage.

This includes a `windows` method on the `Selector` trait to simplify composition and updates the error of the `Best` selector to derive `PartialEq` and `Eq` for comparison in the tests. The `itertools` crate has also been included for the `flatten_ok` method on iterators.