### PR TITLE
Update `Iterable` and `IterableMut` with blanket impls

### DIFF
--- a/packages/brace-ec/src/util/iter.rs
+++ b/packages/brace-ec/src/util/iter.rs
@@ -12,55 +12,20 @@ pub trait Iterable {
     fn iter(&self) -> Self::Iter<'_>;
 }
 
-impl<T> Iterable for [T] {
-    type Item = T;
+impl<T, U> Iterable for T
+where
+    T: ?Sized,
+    for<'a> &'a T: IntoIterator<Item = &'a U>,
+{
+    type Item = U;
 
     type Iter<'a>
-        = std::slice::Iter<'a, T>
+        = <&'a T as IntoIterator>::IntoIter
     where
         Self: 'a;
 
     fn iter(&self) -> Self::Iter<'_> {
-        self.iter()
-    }
-}
-
-impl<const N: usize, T> Iterable for [T; N] {
-    type Item = T;
-
-    type Iter<'a>
-        = std::slice::Iter<'a, T>
-    where
-        T: 'a;
-
-    fn iter(&self) -> Self::Iter<'_> {
-        self.as_slice().iter()
-    }
-}
-
-impl<T> Iterable for Vec<T> {
-    type Item = T;
-
-    type Iter<'a>
-        = std::slice::Iter<'a, T>
-    where
-        T: 'a;
-
-    fn iter(&self) -> Self::Iter<'_> {
-        (**self).iter()
-    }
-}
-
-impl<T> Iterable for Option<T> {
-    type Item = T;
-
-    type Iter<'a>
-        = std::option::Iter<'a, T>
-    where
-        Self: 'a;
-
-    fn iter(&self) -> Self::Iter<'_> {
-        self.iter()
+        self.into_iter()
     }
 }
 
@@ -72,47 +37,18 @@ pub trait IterableMut: Iterable {
     fn iter_mut(&mut self) -> Self::IterMut<'_>;
 }
 
-impl<T> IterableMut for [T] {
+impl<T> IterableMut for T
+where
+    T: Iterable + ?Sized,
+    for<'a> &'a mut T: IntoIterator<Item = &'a mut T::Item>,
+{
     type IterMut<'a>
-        = std::slice::IterMut<'a, T>
-    where
-        T: 'a;
-
-    fn iter_mut(&mut self) -> Self::IterMut<'_> {
-        self.iter_mut()
-    }
-}
-
-impl<const N: usize, T> IterableMut for [T; N] {
-    type IterMut<'a>
-        = std::slice::IterMut<'a, T>
-    where
-        T: 'a;
-
-    fn iter_mut(&mut self) -> Self::IterMut<'_> {
-        self.as_mut_slice().iter_mut()
-    }
-}
-
-impl<T> IterableMut for Vec<T> {
-    type IterMut<'a>
-        = std::slice::IterMut<'a, T>
-    where
-        T: 'a;
-
-    fn iter_mut(&mut self) -> Self::IterMut<'_> {
-        (**self).iter_mut()
-    }
-}
-
-impl<T> IterableMut for Option<T> {
-    type IterMut<'a>
-        = std::option::IterMut<'a, T>
+        = <&'a mut T as IntoIterator>::IntoIter
     where
         Self: 'a;
 
     fn iter_mut(&mut self) -> Self::IterMut<'_> {
-        self.iter_mut()
+        self.into_iter()
     }
 }
 


### PR DESCRIPTION
This updates both the `Iterable` and `IterableMut` traits to use a blanket implementation using `IntoIterator`.

The `Iterable` trait was added as a way to interact with iterable populations without introducing lifetimes or HRTBs in operator implementations. This is due to how iterator conversion is handled using the same `IntoIterator` trait implemented on either owned values, shared references, or exclusive references. The `IterableMut` trait was later added to iterate over mutable references. However, these traits were implemented on specific types which limits the types of population that can be used in some selectors.

This change updates the `Iterable` and `IterableMut` traits to replace the specific implementations with blanket implementations for types that implement `IntoIterator` on references and mutable references respectively. This covers the currently supported types and various other types including those from external libraries.