### PR TITLE
Add additional iterable population helper traits

### DIFF
--- a/packages/brace-ec/src/core/population.rs
+++ b/packages/brace-ec/src/core/population.rs
@@ -1,6 +1,6 @@
 use rand::thread_rng;
 
-use crate::util::iter::Iterable;
+use crate::util::iter::{Iterable, IterableMut, ParIterable, ParIterableMut};
 
 use super::individual::Individual;
 use super::operator::recombinator::Recombinator;
@@ -81,6 +81,27 @@ where
 pub trait IterablePopulation: Population + Iterable<Item = Self::Individual> {}
 
 impl<T> IterablePopulation for T where T: Population + Iterable<Item = Self::Individual> + ?Sized {}
+
+pub trait IterableMutPopulation: Population + IterableMut<Item = Self::Individual> {}
+
+impl<T> IterableMutPopulation for T where
+    T: Population + IterableMut<Item = Self::Individual> + ?Sized
+{
+}
+
+pub trait ParIterablePopulation: Population + ParIterable<Item = Self::Individual> {}
+
+impl<T> ParIterablePopulation for T where
+    T: Population + ParIterable<Item = Self::Individual> + ?Sized
+{
+}
+
+pub trait ParIterableMutPopulation: Population + ParIterableMut<Item = Self::Individual> {}
+
+impl<T> ParIterableMutPopulation for T where
+    T: Population + ParIterableMut<Item = Self::Individual> + ?Sized
+{
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This adds new `IterableMutPopulation`, `ParIterablePopulation` and `ParIterableMutPopulation` helper traits.

The `IterablePopulation` trait was added in #2 to simplify operator trait bounds for iterable populations. This avoided needing to set the associated `Item` to the population individual as this was covered by the new trait. Since then the `IterableMut`, `ParIterable` and `ParIterableMut` traits have been added and so new population traits should also be added.

This change introduces the `IterableMutPopulation`, `ParIterablePopulation` and `ParIterableMutPopulation` traits to assist with simplifying trait bounds. These are implemented with blanket implementations for types satisfying the component traits but the implementation should ideally use trait aliases when those are stabilised.