### PR TITLE
Add `ToOwnedPopulation` helper trait

### DIFF
--- a/packages/brace-ec/src/core/population.rs
+++ b/packages/brace-ec/src/core/population.rs
@@ -103,6 +103,16 @@ impl<T> ParIterableMutPopulation for T where
 {
 }
 
+pub trait ToOwnedPopulation:
+    Population + ToOwned<Owned: Population<Individual = Self::Individual>>
+{
+}
+
+impl<T> ToOwnedPopulation for T where
+    T: Population + ToOwned<Owned: Population<Individual = Self::Individual>> + ?Sized
+{
+}
+
 #[cfg(test)]
 mod tests {
     use crate::core::individual::Individual;


### PR DESCRIPTION
This adds a new `ToOwnedPopulation` helper trait.

The `ToOwned` trait in the standard library is useful for creating owned types from both sized and unsized types. This is implemented on all sized types that implement `Clone` and on unsized types such as slices. Using this trait would allow a selector to work with slices as the input population and returning the sized equivalent, in this case a `Vec`, as the output.

This change introduces a new `ToOwnedPopulation` trait for all types that implement `Population` and `ToOwned` where the associated `Owned` type is a population of the same individual. This helper traits simplifies trait bounds for populations allowing them to omit bounds for the owned type.