### PR TITLE
Update `Fill` and `ParFill` selector impls

### DIFF
--- a/packages/brace-ec/src/core/operator/evolver/select.rs
+++ b/packages/brace-ec/src/core/operator/evolver/select.rs
@@ -3,8 +3,7 @@ use thiserror::Error;
 use crate::core::generation::Generation;
 use crate::core::operator::selector::fill::{Fill, FillError};
 use crate::core::operator::selector::Selector;
-use crate::core::population::Population;
-use crate::util::map::TryMap;
+use crate::core::population::IterableMutPopulation;
 
 use super::Evolver;
 
@@ -23,7 +22,7 @@ impl<S> Select<S> {
 
 impl<P, S> Evolver<(u64, P)> for Select<S>
 where
-    P: Population + Clone + TryMap<Item = P::Individual>,
+    P: IterableMutPopulation + Clone,
     S: Selector<P, Output: IntoIterator<Item = P::Individual>>,
 {
     type Error = SelectError<S::Error>;


### PR DESCRIPTION
This updates the `Fill` and `ParFill` selector implementations using the new helper traits.

The initial implementation of both the `Fill` and `ParFill` selectors only supported sized populations as the input due to the `Clone` bound and in the case of `Fill` the `TryMap` bound too. With the addition of the new helper traits it is possible to update these implementations to support unsized populations such as slices.

This change updates the `Fill` and `ParFill` selectors to use the `ToOwnedPopulation` bound as the input and the associated `Owned` type as the output. This allows sized populations to return the same type and unsized populations to return their sized counterpart.

The `Fill` selector no longer uses the `TryMap` trait and instead uses `IterableMutPopulation` inspired by the use of `IntoParallelIterator` in the `ParFill` selector. This makes more sense as `TryMap` was not actually mapping the old value and instead replacing it. This meant that it did not need the previous value to be owned as long as it had a mutable reference to it. The implementation itself now uses `try_for_each` to update the population as suggested by a lint.

The `ParFill` selector uses `ParIterableMutPopulation` on the owned population to do much the same as the `Fill` selector and instead of mapping and collecting it uses `try_for_each_init` instead. It also now returns the selector error directly instead of a `FillError` as the `NotEnough` variant is not possible with the design. This was originally added to keep the two selectors consistent.

Various variable names have been changed, tests covering the use of slices as input have been added, and the `Select` evolver has been updated using the new bounds.