### PR TITLE
Add `ParWindows` selector adapter

### DIFF
--- a/packages/brace-ec/src/core/operator/selector/mod.rs
+++ b/packages/brace-ec/src/core/operator/selector/mod.rs
@@ -18,7 +18,7 @@ use self::fill::{Fill, ParFill};
 use self::mutate::Mutate;
 use self::recombine::Recombine;
 use self::take::Take;
-use self::windows::{ArrayWindows, Windows};
+use self::windows::{ArrayWindows, ParWindows, Windows};
 
 use super::inspect::Inspect;
 use super::mutator::Mutator;
@@ -92,12 +92,20 @@ where
         ParFill::new(self)
     }
 
-    fn windows<T>(self, count: usize) -> Windows<Self, T>
+    fn windows<T>(self, size: usize) -> Windows<Self, T>
     where
         T: AsRef<[P::Individual]> + ?Sized,
         Self: Selector<[P::Individual]>,
     {
-        Windows::new(self, count)
+        Windows::new(self, size)
+    }
+
+    fn par_windows<T>(self, size: usize) -> ParWindows<Self, T>
+    where
+        T: AsRef<[P::Individual]> + ?Sized,
+        Self: Selector<[P::Individual]>,
+    {
+        ParWindows::new(self, size)
     }
 
     fn array_windows<const N: usize, T>(self) -> ArrayWindows<N, Self, T>


### PR DESCRIPTION
This adds a new `ParWindows` selector based on the `Windows` selector.

The `Windows` selector adapter was added in #66 to apply a selector to windows of a population. However, since then support for parallel selectors has been added using the `rayon` crate. Parallel versions of various other operators should be added.

This change adds a new `ParWindows` selector based on the `Windows` selector but using `par_windows` from `rayon` instead of `windows`. This relies on using `flat_map_iter` to handle the `flatten_ok`. It also sneaks in an update to the `windows` method on `Selector` to rename the parameter `count` to `size` which was leftover from copying `repeat`.