### PR TITLE
Add `ParArrayWindows` selector adapter

### DIFF
--- a/packages/brace-ec/src/core/operator/selector/mod.rs
+++ b/packages/brace-ec/src/core/operator/selector/mod.rs
@@ -18,7 +18,7 @@ use self::fill::{Fill, ParFill};
 use self::mutate::Mutate;
 use self::recombine::Recombine;
 use self::take::Take;
-use self::windows::{ArrayWindows, ParWindows, Windows};
+use self::windows::{ArrayWindows, ParArrayWindows, ParWindows, Windows};
 
 use super::inspect::Inspect;
 use super::mutator::Mutator;
@@ -114,6 +114,14 @@ where
         Self: Selector<[P::Individual; N]>,
     {
         ArrayWindows::new(self)
+    }
+
+    fn par_array_windows<const N: usize, T>(self) -> ParArrayWindows<N, Self, T>
+    where
+        T: AsRef<[P::Individual]> + ?Sized,
+        Self: Selector<[P::Individual; N]>,
+    {
+        ParArrayWindows::new(self)
     }
 
     fn take<const N: usize>(self) -> Take<Self, N>


### PR DESCRIPTION
This adds a new `ParArrayWindows` selector adapter based on the `ArrayWindows` and `ParWindows` selectors.

The `ParWindows` selector adapter was added in #75 to provide a parallel version of `Windows`. However, the `ArrayWindows` selector adapter should also have a parallel implementation.

This change introduces a new `ParArrayWindows` selector adapter using code from both the `ArrayWindows` and `ParWindows` selector adapters. This includes a new `par_array_windows` method on the `Selector` trait.