### PR TITLE
Add support for parallel selection in image example

### DIFF
--- a/examples/image/src/args.rs
+++ b/examples/image/src/args.rs
@@ -22,4 +22,8 @@ pub struct Args {
     /// The mutation rate.
     #[arg(long, default_value_t = 0.1)]
     pub rate: f64,
+
+    /// Enable parallel selection.
+    #[arg(long)]
+    pub parallel: bool,
 }

--- a/examples/image/src/evolver.rs
+++ b/examples/image/src/evolver.rs
@@ -13,9 +13,9 @@ pub struct ImageEvolver {
 }
 
 impl ImageEvolver {
-    pub fn new(scorer: ImageScorer, rate: f64) -> Self {
+    pub fn new(scorer: ImageScorer, rate: f64, parallel: bool) -> Self {
         Self {
-            selector: ImageSelector::new(scorer, rate),
+            selector: ImageSelector::new(scorer, rate, parallel),
         }
     }
 }

--- a/examples/image/src/main.rs
+++ b/examples/image/src/main.rs
@@ -52,7 +52,7 @@ fn main() -> Result<(), Error> {
     }
 
     let evolver = Terminal::new(
-        ImageEvolver::new(scorer, args.rate),
+        ImageEvolver::new(scorer, args.rate, args.parallel),
         ImageRenderer::new(Image::new(image)),
     );
 


### PR DESCRIPTION
This updates the `image` example to add support for parallel selection.

The `image` evolver example was added in #68 to demonstrate the use of this project to build an evolutionary computation algorithm and application. The implementation used the `ArrayWindows` selector adapter but this runs in serial so it could be quite slow with large populations. However, the `ParArrayWindows` selector adapter could be used to speed it up.

This change adds a new `--parallel` flag to the `image` example CLI to enable parallel selection. This default to *false* as it can be computationally expensive. It internally uses an enum with variants for serial and parallel where the serial variant uses `ArrayWindows` and the parallel variant uses `ParArrayWindows`. These share the same error type so that does not need to be changed.