### PR TITLE
Add support for parallel scoring in image example

### DIFF
--- a/examples/image/src/selector.rs
+++ b/examples/image/src/selector.rs
@@ -17,13 +17,13 @@ pub enum ImageSelector {
     Serial(
         And<
             First<[Scored<Image, u64>]>,
-            Score<ArrayWindows<2, ImageWindowsSelector, [Scored<Image, u64>]>, ImageScorer>,
+            ArrayWindows<2, Score<ImageWindowsSelector, ImageScorer>, [Scored<Image, u64>]>,
         >,
     ),
     Parallel(
         And<
             First<[Scored<Image, u64>]>,
-            Score<ParArrayWindows<2, ImageWindowsSelector, [Scored<Image, u64>]>, ImageScorer>,
+            ParArrayWindows<2, Score<ImageWindowsSelector, ImageScorer>, [Scored<Image, u64>]>,
         >,
     ),
 }
@@ -34,15 +34,15 @@ impl ImageSelector {
             false => Self::Serial(
                 First.and(
                     ImageWindowsSelector::new(rate)
-                        .array_windows()
-                        .score(scorer),
+                        .score(scorer)
+                        .array_windows(),
                 ),
             ),
             true => Self::Parallel(
                 First.and(
                     ImageWindowsSelector::new(rate)
-                        .par_array_windows()
-                        .score(scorer),
+                        .score(scorer)
+                        .par_array_windows(),
                 ),
             ),
         }
@@ -75,7 +75,7 @@ impl Selector<Vec<Scored<Image, u64>>> for ImageSelector {
 #[derive(Debug, Error)]
 #[error(transparent)]
 pub struct ImageSelectorError(
-    AndError<FirstError, ScoreError<WindowsError<Infallible>, Infallible>>,
+    AndError<FirstError, WindowsError<ScoreError<Infallible, Infallible>>>,
 );
 
 pub struct ImageWindowsSelector {


### PR DESCRIPTION
This updates the `image` example to add support for parallel scoring.

The previous update #77 changed the `image` example to support parallel selection. However, as the order of operations is important, it did not score in parallel. This was because `score` is called after `par_windows` and not before. This did not matter in the serial version but as the implementation was copied by switching from `ArrayWindows` to `ParArrayWindows` this was not included.

This change updates the internal logic of the `ImageSelector` to ensure that `score` is called before `windows` and `par_windows`. This makes both the serial and parallel versions roughly equivalent even though the change should not affect the serial version in any meaningful way. This also keeps the errors consistent.