### PR TITLE
Add `Generation::advance` methods

### DIFF
--- a/packages/brace-ec/src/core/generation.rs
+++ b/packages/brace-ec/src/core/generation.rs
@@ -14,7 +14,28 @@ pub trait Generation {
 
     fn population_mut(&mut self) -> &mut Self::Population;
 
-    fn advance(&mut self, population: Self::Population) -> Self::Population;
+    fn advance(&mut self);
+
+    fn advance_with(&mut self, population: impl Into<Self::Population>) -> Self::Population {
+        self.advance();
+        std::mem::replace(self.population_mut(), population.into())
+    }
+
+    fn advanced(mut self) -> Self
+    where
+        Self: Sized,
+    {
+        self.advance();
+        self
+    }
+
+    fn advanced_with(mut self, population: impl Into<Self::Population>) -> Self
+    where
+        Self: Sized,
+    {
+        self.advance_with(population);
+        self
+    }
 }
 
 impl<T, P> Generation for (T, P)
@@ -37,10 +58,8 @@ where
         &mut self.1
     }
 
-    fn advance(&mut self, population: Self::Population) -> Self::Population {
+    fn advance(&mut self) {
         self.0 += T::one();
-
-        std::mem::replace(self.population_mut(), population)
     }
 }
 

--- a/packages/brace-ec/src/core/generation.rs
+++ b/packages/brace-ec/src/core/generation.rs
@@ -1,3 +1,7 @@
+use std::ops::AddAssign;
+
+use num_traits::One;
+
 use super::population::Population;
 
 pub trait Generation {
@@ -9,10 +13,13 @@ pub trait Generation {
     fn population(&self) -> &Self::Population;
 
     fn population_mut(&mut self) -> &mut Self::Population;
+
+    fn advance(&mut self, population: Self::Population) -> Self::Population;
 }
 
 impl<T, P> Generation for (T, P)
 where
+    T: AddAssign + One,
     P: Population,
 {
     type Id = T;
@@ -28,6 +35,12 @@ where
 
     fn population_mut(&mut self) -> &mut Self::Population {
         &mut self.1
+    }
+
+    fn advance(&mut self, population: Self::Population) -> Self::Population {
+        self.0 += T::one();
+
+        std::mem::replace(self.population_mut(), population)
     }
 }
 


### PR DESCRIPTION
This adds a new `advance` method to the `Generation` trait.

The `Generation` trait represents an iteration of a population and currently the only implementation is a tuple. The `Select` evolver implementation only supports the tuple generation where the first item is a `u64`. This was chosen because a `u64` is a reasonable option for an incrementing number that shouldn't reach the maximum and a tuple has a known structure. Using these together allows the evolver to increment the generation identifier. However, the `Generation` trait should instead provide a way to increment the identifier without knowing specific details about the type. This will allow the evolver to support additional types of generation.

This change adds a new `advance` method to the `Generation` trait that advances the generation. This is intended to increment the generation identifier but may perform other behaviour such as alter the population although that should probably be handled by the evolver instead. This should allow evolvers to be generic over the population type as they no longer need to know how to access and increment the identifier.

This also includes default `advance_with`, `advanced` and `advanced_with` methods that use `advance`. The former updates the population in addition to calling `advance` and the latter two are variants that take ownership instead of a mutable reference.

This updates the tuple implementation to require the `AddAssign` and `One` trait bounds on the identifier so that it can be incremented by one. This should support the standard numeric types but other types may implement those traits or another generation could be used to support different identifiers.