### PR TITLE
Redesign `Select` evolver

### DIFF
--- a/packages/brace-ec-tui/examples/noise.rs
+++ b/packages/brace-ec-tui/examples/noise.rs
@@ -16,7 +16,7 @@ use ratatui::Frame;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let selector = Tournament::binary().mutate(Noise(1..5).rate(0.25));
-    let evolver = Terminal::new(Select::new(selector), NoiseRenderer);
+    let evolver = Terminal::new(Select::fill(selector), NoiseRenderer);
 
     evolver.evolve((0, vec![0; 500]), &mut rand::thread_rng())?;
 

--- a/packages/brace-ec/examples/average.rs
+++ b/packages/brace-ec/examples/average.rs
@@ -19,7 +19,7 @@ pub fn main() {
 
     print_generation(&generation);
 
-    Select::new(selector)
+    Select::fill(selector)
         .repeat(10)
         .inspect(print_generation)
         .repeat(10)

--- a/packages/brace-ec/src/core/operator/evolver/select.rs
+++ b/packages/brace-ec/src/core/operator/evolver/select.rs
@@ -62,6 +62,7 @@ where
 mod tests {
     use crate::core::operator::evolver::Evolver;
     use crate::core::operator::selector::random::Random;
+    use crate::core::operator::selector::Selector;
 
     use super::Select;
 
@@ -79,6 +80,18 @@ mod tests {
         let generation = evolver.evolve(generation, &mut rng).unwrap();
 
         assert_eq!(generation.0, 2);
+        assert!(generation.1.iter().all(|i| population.contains(i)));
+
+        let population = [1, 2, 3, 4, 5];
+        let generation = Random
+            .fill()
+            .evolver()
+            .repeat(2)
+            .evolve((0, population), &mut rng)
+            .unwrap();
+
+        assert_eq!(generation.0, 2);
+        assert_eq!(generation.1.len(), 5);
         assert!(generation.1.iter().all(|i| population.contains(i)));
     }
 }

--- a/packages/brace-ec/src/core/operator/inspect.rs
+++ b/packages/brace-ec/src/core/operator/inspect.rs
@@ -132,7 +132,7 @@ mod tests {
     fn test_evolve() {
         let mut rng = rand::thread_rng();
 
-        Select::new(First)
+        Select::fill(First)
             .inspect(|(i, population)| {
                 assert_eq!(i, &1);
                 assert_eq!(population, &[0, 0, 0, 0, 0]);

--- a/packages/brace-ec/src/core/operator/repeat.rs
+++ b/packages/brace-ec/src/core/operator/repeat.rs
@@ -171,14 +171,14 @@ mod tests {
     fn test_evolve() {
         let mut rng = rand::thread_rng();
 
-        let a = Select::new(First)
+        let a = Select::fill(First)
             .repeat(2)
             .evolve((0, [0, 1, 2, 3, 4]), &mut rng)
             .unwrap();
 
         assert_eq!(a.0, 2);
 
-        let b = Select::new(First)
+        let b = Select::fill(First)
             .repeat(2)
             .repeat(3)
             .evolve((0, [0, 1, 2, 3, 4]), &mut rng)

--- a/packages/brace-ec/src/core/operator/score.rs
+++ b/packages/brace-ec/src/core/operator/score.rs
@@ -251,15 +251,15 @@ mod tests {
     fn test_evolve() {
         let mut rng = rand::thread_rng();
 
-        let a = Select::new(First)
+        let a = Select::fill(First)
             .score(Function::new(double))
             .evolve((0, [Scored::new(10, 0), Scored::new(20, 0)]), &mut rng)
             .unwrap();
-        let b = Select::new(First)
+        let b = Select::fill(First)
             .score(Function::new(triple))
             .evolve((0, [Scored::new(10, 0), Scored::new(20, 0)]), &mut rng)
             .unwrap();
-        let c = Select::new(First)
+        let c = Select::fill(First)
             .score_with(|individual: &Scored<i32, i32>| {
                 Ok::<_, Infallible>(individual.individual * 4)
             })

--- a/packages/brace-ec/src/core/operator/selector/fill.rs
+++ b/packages/brace-ec/src/core/operator/selector/fill.rs
@@ -1,6 +1,7 @@
 use rayon::iter::ParallelIterator;
 use thiserror::Error;
 
+use crate::core::operator::evolver::select::Select;
 use crate::core::population::{IterableMutPopulation, ParIterableMutPopulation, ToOwnedPopulation};
 use crate::util::iter::{IterableMut, ParIterableMut};
 
@@ -14,6 +15,10 @@ pub struct Fill<S> {
 impl<S> Fill<S> {
     pub fn new(selector: S) -> Self {
         Self { selector }
+    }
+
+    pub fn evolver<G>(self) -> Select<Self, G> {
+        Select::new(self)
     }
 }
 
@@ -75,6 +80,10 @@ pub struct ParFill<S> {
 impl<S> ParFill<S> {
     pub fn new(selector: S) -> Self {
         Self { selector }
+    }
+
+    pub fn evolver<G>(self) -> Select<Self, G> {
+        Select::new(self)
     }
 }
 

--- a/packages/brace-ec/src/core/operator/selector/fill.rs
+++ b/packages/brace-ec/src/core/operator/selector/fill.rs
@@ -1,7 +1,6 @@
 use rayon::iter::ParallelIterator;
 use thiserror::Error;
 
-use crate::core::operator::evolver::select::Select;
 use crate::core::population::{IterableMutPopulation, ParIterableMutPopulation, ToOwnedPopulation};
 use crate::util::iter::{IterableMut, ParIterableMut};
 
@@ -15,10 +14,6 @@ pub struct Fill<S> {
 impl<S> Fill<S> {
     pub fn new(selector: S) -> Self {
         Self { selector }
-    }
-
-    pub fn evolver<G>(self) -> Select<Self, G> {
-        Select::new(self)
     }
 }
 
@@ -80,10 +75,6 @@ pub struct ParFill<S> {
 impl<S> ParFill<S> {
     pub fn new(selector: S) -> Self {
         Self { selector }
-    }
-
-    pub fn evolver<G>(self) -> Select<Self, G> {
-        Select::new(self)
     }
 }
 

--- a/packages/brace-ec/src/core/operator/selector/mod.rs
+++ b/packages/brace-ec/src/core/operator/selector/mod.rs
@@ -11,6 +11,7 @@ pub mod windows;
 pub mod worst;
 
 use crate::core::fitness::{Fitness, FitnessMut};
+use crate::core::generation::Generation;
 use crate::core::population::Population;
 
 use self::and::And;
@@ -20,6 +21,7 @@ use self::recombine::Recombine;
 use self::take::Take;
 use self::windows::{ArrayWindows, ParArrayWindows, ParWindows, Windows};
 
+use super::evolver::select::Select;
 use super::inspect::Inspect;
 use super::mutator::Mutator;
 use super::recombinator::Recombinator;
@@ -68,6 +70,13 @@ where
         P::Individual: FitnessMut,
     {
         self.score(Function::new(scorer))
+    }
+
+    fn evolver<G>(self) -> Select<Self, G>
+    where
+        G: Generation<Population = P>,
+    {
+        Select::new(self)
     }
 
     fn and<S>(self, selector: S) -> And<Self, S>

--- a/packages/brace-ec/src/core/operator/then.rs
+++ b/packages/brace-ec/src/core/operator/then.rs
@@ -196,13 +196,13 @@ mod tests {
     fn test_evolve() {
         let mut rng = rand::thread_rng();
 
-        let a = Select::new(Best)
-            .then(Select::new(First))
+        let a = Select::fill(Best)
+            .then(Select::fill(First))
             .evolve((0, [0, 1, 2, 3, 4]), &mut rng)
             .unwrap();
 
-        let b = Select::new(First)
-            .then(Select::new(Best))
+        let b = Select::fill(First)
+            .then(Select::fill(Best))
             .evolve((0, [0, 1, 2, 3, 4]), &mut rng)
             .unwrap();
 

--- a/packages/brace-ec/src/core/operator/weighted.rs
+++ b/packages/brace-ec/src/core/operator/weighted.rs
@@ -311,16 +311,16 @@ mod tests {
         let mut rng = rand::thread_rng();
 
         for _ in 0..10 {
-            let a = Weighted::evolver(Select::new(Best), 1)
-                .with_evolver(Select::new(Worst), 1)
+            let a = Weighted::evolver(Select::fill(Best), 1)
+                .with_evolver(Select::fill(Worst), 1)
                 .evolve((0, [0, 1, 2, 3, 4]), &mut rng)
                 .unwrap();
-            let b = Weighted::evolver(Select::new(Best), 1)
-                .with_evolver(Select::new(Worst), 0)
+            let b = Weighted::evolver(Select::fill(Best), 1)
+                .with_evolver(Select::fill(Worst), 0)
                 .evolve((0, [0, 1, 2, 3, 4]), &mut rng)
                 .unwrap();
-            let c = Weighted::evolver(Select::new(Best), 0)
-                .with_evolver(Select::new(Worst), 1)
+            let c = Weighted::evolver(Select::fill(Best), 0)
+                .with_evolver(Select::fill(Worst), 1)
                 .evolve((0, [0, 1, 2, 3, 4]), &mut rng)
                 .unwrap();
 


### PR DESCRIPTION
This redesigns the `Select` evolver to support more than just `Fill` selectors.

The implementation of the `Select` evolver currently only supports using the `Fill` selector adapter. With the addition of the `ParFill` selector adapter in #69 it became apparent that there was a need to either add a new `ParSelect` evolver or redesign the existing `Select` evolver. It would have been possible to use the `ParFill` selector within the `Select` evolver but this would have caused the population to be unnecessarily cloned.

The implementation of the `Select` evolver is also limited to a single type of generation. With the new ability to advance generations in #79 it is possible to redesign the evolver to support additional types of generation.

This change updates the `Select` evolver to no longer store a `Fill` selector but instead any selector. The current `new` constructor becomes `fill`, a `par_fill` constructor supports `ParFill`, and the updated `new` constructor would allow either `Fill`, `ParFill`, or any other selector. The only requirement is that the selector use the generation's population as the input and its output can be converted into the same population. This means that a selector like `Best` could be used for a `Vec` population even though it returns an array. However, that would resize the population which may not be what users want.

The new implementation simply calls the `advanced_with` method on the generation, allowing it to advance the generation identifier and apply any other changes.

The need for this type to still exist is because operator chaining requires type inference to work and implementing `Evolver` directly on types such as `Fill` and `ParFill` would require a generic `G` to denote the generation type. This would then break selection as it does not use a generation and therefore could not be inferred.