### PR TITLE
Add `Generator` operator trait

### DIFF
--- a/packages/brace-ec/src/core/operator/generator/mod.rs
+++ b/packages/brace-ec/src/core/operator/generator/mod.rs
@@ -1,0 +1,47 @@
+pub trait Generator<T>: Sized {
+    type Error;
+
+    fn generate<Rng>(&self, rng: &mut Rng) -> Result<T, Self::Error>
+    where
+        Rng: rand::Rng + ?Sized;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+    use std::convert::Infallible;
+
+    use super::Generator;
+
+    struct Count(Cell<u8>);
+
+    impl Generator<u8> for Count {
+        type Error = Infallible;
+
+        fn generate<Rng>(&self, _: &mut Rng) -> Result<u8, Self::Error>
+        where
+            Rng: rand::Rng + ?Sized,
+        {
+            let n = self.0.get() + 1;
+
+            self.0.set(n);
+
+            Ok(n)
+        }
+    }
+
+    #[test]
+    fn test_generate() {
+        let mut rng = rand::thread_rng();
+
+        let count = Count(Cell::new(0));
+
+        let a = count.generate(&mut rng).unwrap();
+        let b = count.generate(&mut rng).unwrap();
+        let c = count.generate(&mut rng).unwrap();
+
+        assert_eq!(a, 1);
+        assert_eq!(b, 2);
+        assert_eq!(c, 3);
+    }
+}

--- a/packages/brace-ec/src/core/operator/mod.rs
+++ b/packages/brace-ec/src/core/operator/mod.rs
@@ -1,4 +1,5 @@
 pub mod evolver;
+pub mod generator;
 pub mod inspect;
 pub mod mutator;
 pub mod recombinator;


### PR DESCRIPTION
This adds a new `Generator` operator trait for generating values.

The project is currently missing the ability to generate the initial population for the call to `Evolver::evolve`. The `image` example manually creates a population using a loop, an iterator, and the `rand` crate but it would be useful to provide a new set of operators to generate individuals and populations.

This change introduces a new `Generator` operator trait that returns a new value when `generate` is called. This resembles the `Distribution` trait from `rand` except that it returns a `Result`, allowing generators to fail at runtime. Although the trait, like the other operator traits, takes a random number generator it does not imply that it only generates random values. The small example shows that it can use interior mutability to produce an incrementing output that does not use the random number generator.