### PR TITLE
Add `Uniform` generator

### DIFF
--- a/packages/brace-ec/src/core/operator/generator/mod.rs
+++ b/packages/brace-ec/src/core/operator/generator/mod.rs
@@ -1,3 +1,5 @@
+pub mod uniform;
+
 pub trait Generator<T>: Sized {
     type Error;
 

--- a/packages/brace-ec/src/core/operator/generator/uniform.rs
+++ b/packages/brace-ec/src/core/operator/generator/uniform.rs
@@ -1,0 +1,86 @@
+use std::convert::Infallible;
+use std::ops::{Range, RangeInclusive};
+
+use rand::distributions::uniform::{SampleBorrow, SampleUniform, Uniform as RandUniform};
+use rand::distributions::Distribution;
+
+use super::Generator;
+
+pub struct Uniform<T>(RandUniform<T>)
+where
+    T: SampleUniform;
+
+impl<T> Uniform<T>
+where
+    T: SampleUniform,
+{
+    pub fn new<L, H>(low: L, high: H) -> Uniform<T>
+    where
+        L: SampleBorrow<T> + Sized,
+        H: SampleBorrow<T> + Sized,
+    {
+        Uniform(RandUniform::new(low, high))
+    }
+
+    pub fn new_inclusive<L, H>(low: L, high: H) -> Uniform<T>
+    where
+        L: SampleBorrow<T> + Sized,
+        H: SampleBorrow<T> + Sized,
+    {
+        Uniform(RandUniform::new_inclusive(low, high))
+    }
+}
+
+impl<T> Generator<T> for Uniform<T>
+where
+    T: SampleUniform,
+{
+    type Error = Infallible;
+
+    fn generate<Rng>(&self, rng: &mut Rng) -> Result<T, Self::Error>
+    where
+        Rng: rand::Rng + ?Sized,
+    {
+        Ok(self.0.sample(rng))
+    }
+}
+
+impl<T> From<Range<T>> for Uniform<T>
+where
+    T: SampleUniform,
+{
+    fn from(range: Range<T>) -> Uniform<T> {
+        Uniform::new(range.start, range.end)
+    }
+}
+
+impl<T> From<RangeInclusive<T>> for Uniform<T>
+where
+    T: SampleUniform,
+{
+    fn from(range: RangeInclusive<T>) -> Uniform<T> {
+        Uniform::new_inclusive(range.start(), range.end())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::operator::generator::Generator;
+
+    use super::Uniform;
+
+    #[test]
+    fn test_generate() {
+        let mut rng = rand::thread_rng();
+
+        for _ in 0..100 {
+            let a: u8 = Uniform::from(0..10).generate(&mut rng).unwrap();
+            let b: usize = Uniform::from(0..10).generate(&mut rng).unwrap();
+            let c: i64 = Uniform::from(0..10).generate(&mut rng).unwrap();
+
+            assert!(a < 10);
+            assert!(b < 10);
+            assert!((0..10).contains(&c));
+        }
+    }
+}


### PR DESCRIPTION
This adds a new `Uniform` generator to generate values in a given range.

The `image` example currently uses the `Rng::gen_range` method to generate random numbers in the given range. In order to replace the population generation with a new `Generator`-based implementation it is necessary to create a generator that generates from a range.

This change introduces the `Uniform` generator that wraps the `Uniform` distribution from the `rand` crate with an almost-identical API. The reason for this and not simply re-exporting the type from `rand` is that it hides the implementation details and allows the API to be changed independently to `rand`. For example, this does not yet deal with invalid ranges and the next version of `rand` introduces checks at construction whereas this would rather return a runtime error to simplify operator composition.