### PR TITLE
Implement `TryFromIterator` for `Result`

### DIFF
--- a/packages/brace-ec/src/util/iter.rs
+++ b/packages/brace-ec/src/util/iter.rs
@@ -1,6 +1,6 @@
 use std::convert::Infallible;
 
-use itertools::Itertools;
+use itertools::process_results;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use thiserror::Error;
 
@@ -161,11 +161,7 @@ where
     where
         I: IntoIterator<Item = Result<T, E>>,
     {
-        let res = iter
-            .into_iter()
-            .process_results(|iter| U::try_from_iter(iter));
-
-        Ok(match res {
+        Ok(match process_results(iter, |it: _| U::try_from_iter(it)) {
             Ok(res) => Ok(res?),
             Err(err) => Err(err),
         })


### PR DESCRIPTION
This simply implements `TryFromIterator` for `Result`.

The `FromIterator` trait in the standard library has a very useful implementation on `Result` that converts an iterator of results to a result of collected success values. This allows an iterator to end on the first error and return that or complete the iteration and collect as if it was not an iterator of results. This functionality would be useful to apply to the `TryFromIterator` trait.

This change introduces a new implementation of `TryFromIterator` for `Result` that returns a double-result where the outer error is the result of collecting the `Ok` variants and the inner error is the error from the iterator. This avoids the need for a temporary allocation to collect to a `Result<Vec>` before iterating again to collect to the desired type.

The implementation of this would be tricky if not for `process_results` from the `itertools` crate which performs the same function as the internal `try_process` in the standard library.