### PR TITLE
Add `Populate` generator adapter

### DIFF
--- a/packages/brace-ec/src/core/operator/generator/mod.rs
+++ b/packages/brace-ec/src/core/operator/generator/mod.rs
@@ -1,4 +1,10 @@
+pub mod populate;
 pub mod uniform;
+
+use crate::core::population::Population;
+use crate::util::iter::TryFromIterator;
+
+use self::populate::Populate;
 
 pub trait Generator<T>: Sized {
     type Error;
@@ -6,6 +12,13 @@ pub trait Generator<T>: Sized {
     fn generate<Rng>(&self, rng: &mut Rng) -> Result<T, Self::Error>
     where
         Rng: rand::Rng + ?Sized;
+
+    fn populate<P>(self, size: usize) -> Populate<Self, P>
+    where
+        P: Population<Individual = T> + TryFromIterator<T>,
+    {
+        Populate::new(self, size)
+    }
 }
 
 #[cfg(test)]

--- a/packages/brace-ec/src/core/operator/generator/populate.rs
+++ b/packages/brace-ec/src/core/operator/generator/populate.rs
@@ -1,0 +1,75 @@
+use std::iter::repeat_with;
+use std::marker::PhantomData;
+
+use thiserror::Error;
+
+use crate::core::population::Population;
+use crate::util::iter::TryFromIterator;
+
+use super::Generator;
+
+pub struct Populate<T, P> {
+    generator: T,
+    size: usize,
+    marker: PhantomData<fn() -> P>,
+}
+
+impl<T, P> Populate<T, P> {
+    pub fn new(generator: T, size: usize) -> Self {
+        Self {
+            generator,
+            size,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<P, T> Generator<P> for Populate<T, P>
+where
+    P: Population + TryFromIterator<P::Individual>,
+    T: Generator<P::Individual>,
+{
+    type Error = PopulateError<P::Error, T::Error>;
+
+    fn generate<Rng>(&self, rng: &mut Rng) -> Result<P, Self::Error>
+    where
+        Rng: rand::Rng + ?Sized,
+    {
+        let iter = repeat_with(|| self.generator.generate(rng)).take(self.size);
+
+        Result::try_from_iter(iter)
+            .map_err(PopulateError::Collect)?
+            .map_err(PopulateError::Generate)
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum PopulateError<C, G> {
+    #[error(transparent)]
+    Collect(C),
+    #[error(transparent)]
+    Generate(G),
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::operator::generator::uniform::Uniform;
+    use crate::core::operator::generator::Generator;
+
+    #[test]
+    fn test_generate() {
+        let mut rng = rand::thread_rng();
+
+        let a: Vec<u8> = Uniform::from(1..2).populate(5).generate(&mut rng).unwrap();
+        let b: [u8; 5] = Uniform::from(1..2).populate(5).generate(&mut rng).unwrap();
+        let c: [[u8; 2]; 3] = Uniform::from(1..2)
+            .populate(2)
+            .populate(3)
+            .generate(&mut rng)
+            .unwrap();
+
+        assert_eq!(a, [1; 5]);
+        assert_eq!(b, [1; 5]);
+        assert_eq!(c, [[1; 2]; 3]);
+    }
+}


### PR DESCRIPTION
This adds a new `Populate` generator adapter to fill a population with an individual generator.

The `Generator` operator added in #81 was designed to generate individuals, populations, and generations in a single trait using the same composition structure as the other operators. So far only the `Uniform` generator exists to generate individuals in a range but there should be a simple way to generate a population from an individual generator.

This change introduces the `Populate` generator adapter that generates a population of the specified size using the `TryFromIterator` trait. This supports any population that implements the trait including both vectors and arrays. The manual size input is perhaps not ideal for fixed-length arrays as a number that is too small will result in a runtime error and a number that is too large will needlessly generate extra individuals. However, it is necessary to support vectors and other collections with a dynamic length.