### PR TITLE
Add `Generate` selector

### DIFF
--- a/packages/brace-ec/src/core/operator/generator/mod.rs
+++ b/packages/brace-ec/src/core/operator/generator/mod.rs
@@ -6,6 +6,8 @@ use crate::util::iter::TryFromIterator;
 
 use self::populate::Populate;
 
+use super::selector::generate::Generate;
+
 pub trait Generator<T>: Sized {
     type Error;
 
@@ -18,6 +20,13 @@ pub trait Generator<T>: Sized {
         P: Population<Individual = T> + TryFromIterator<T>,
     {
         Populate::new(self, size)
+    }
+
+    fn selector<P>(self) -> Generate<Self, P>
+    where
+        P: Population<Individual = T>,
+    {
+        Generate::new(self)
     }
 }
 

--- a/packages/brace-ec/src/core/operator/selector/generate.rs
+++ b/packages/brace-ec/src/core/operator/selector/generate.rs
@@ -1,0 +1,54 @@
+use std::marker::PhantomData;
+
+use crate::core::operator::generator::Generator;
+use crate::core::population::Population;
+
+use super::Selector;
+
+pub struct Generate<T, P> {
+    generator: T,
+    marker: PhantomData<fn() -> P>,
+}
+
+impl<T, P> Generate<T, P> {
+    pub fn new(generator: T) -> Self {
+        Self {
+            generator,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<P, T> Selector<P> for Generate<T, P>
+where
+    P: Population,
+    T: Generator<P::Individual>,
+{
+    type Output = [P::Individual; 1];
+    type Error = T::Error;
+
+    fn select<Rng>(&self, _: &P, rng: &mut Rng) -> Result<Self::Output, Self::Error>
+    where
+        Rng: rand::Rng + ?Sized,
+    {
+        Ok([self.generator.generate(rng)?])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::operator::generator::uniform::Uniform;
+    use crate::core::operator::generator::Generator;
+    use crate::core::population::Population;
+
+    #[test]
+    fn test_select() {
+        let population = [1, 2, 3, 4, 5];
+
+        let a = population.select(Uniform::from(6..10).selector()).unwrap();
+        let b = population.select(Uniform::from(1..2).selector()).unwrap();
+
+        assert!(a[0] >= 6 && a[0] < 10);
+        assert_eq!(b, [1]);
+    }
+}

--- a/packages/brace-ec/src/core/operator/selector/mod.rs
+++ b/packages/brace-ec/src/core/operator/selector/mod.rs
@@ -2,6 +2,7 @@ pub mod and;
 pub mod best;
 pub mod fill;
 pub mod first;
+pub mod generate;
 pub mod mutate;
 pub mod random;
 pub mod recombine;


### PR DESCRIPTION
This adds a new `Generate` selector to select using a generator.

The `Generator` operator trait was introduced in #81 to support generating new individuals and populations and this works well to create the initial population but there may also be a need to use a generator as a selector. This may seem to go against the idea of the operator in evolutionary computation but in this project the purpose of a selector is to select new individuals for the next generation from any source, whether it is from the population, a fixed value, or a random value.

This change adds a new `Generate` selector that uses the inner generator to generate a new individual rather than select one from the existing population. This is intended to be used with operators such as `And` so that users can select from the population and recombine it with something from outside the population.

This includes a new `selector` method on the `Generate` trait to use the new selector through method chaining. This is to avoid implementing the `Selector` trait on individual generators as that would require extra boilerplate and cause issues with type inference when calling a method with a name that exists in both traits.