### PR TITLE
Add `ImageGenerator` to image example

### DIFF
--- a/examples/image/src/generator.rs
+++ b/examples/image/src/generator.rs
@@ -1,0 +1,37 @@
+use std::convert::Infallible;
+
+use brace_ec::core::individual::scored::Scored;
+use brace_ec::core::operator::generator::uniform::Uniform;
+use brace_ec::core::operator::generator::Generator;
+use image::GrayImage;
+
+use crate::individual::Image;
+
+pub struct ImageGenerator {
+    width: u32,
+    height: u32,
+}
+
+impl ImageGenerator {
+    pub fn new(width: u32, height: u32) -> Self {
+        Self { width, height }
+    }
+}
+
+impl Generator<Scored<Image, u64>> for ImageGenerator {
+    type Error = Infallible;
+
+    fn generate<Rng>(&self, rng: &mut Rng) -> Result<Scored<Image, u64>, Self::Error>
+    where
+        Rng: rand::Rng + ?Sized,
+    {
+        let pixels = Uniform::from(0..=255)
+            .populate(self.width as usize * self.height as usize)
+            .generate(rng)
+            .expect("infallible");
+
+        let image = GrayImage::from_vec(self.width, self.height, pixels).expect("valid");
+
+        Ok(Scored::new(Image::new(image), 0))
+    }
+}

--- a/examples/image/src/main.rs
+++ b/examples/image/src/main.rs
@@ -1,23 +1,21 @@
 mod args;
 mod evolver;
+mod generator;
 mod individual;
 mod renderer;
 mod scorer;
 mod selector;
 
-use anyhow::{Context, Error};
-use brace_ec::core::fitness::FitnessMut;
-use brace_ec::core::individual::scored::Scored;
+use anyhow::Error;
 use brace_ec::core::operator::evolver::Evolver;
-use brace_ec::core::operator::scorer::Scorer;
+use brace_ec::core::operator::generator::Generator;
 use brace_ec_tui::evolver::Terminal;
 use clap::Parser;
 use image::imageops::FilterType;
-use image::GrayImage;
-use rand::Rng;
 
 use self::args::Args;
 use self::evolver::ImageEvolver;
+use self::generator::ImageGenerator;
 use self::individual::Image;
 use self::renderer::ImageRenderer;
 use self::scorer::ImageScorer;
@@ -30,26 +28,14 @@ fn main() -> Result<(), Error> {
         .resize(args.width, args.height, FilterType::Nearest)
         .into_luma8();
 
-    let mut population = Vec::with_capacity(args.population);
     let mut rng = rand::thread_rng();
 
     let scorer = ImageScorer::new(Image::new(image.clone()));
+    let generator = ImageGenerator::new(image.width(), image.height())
+        .score(scorer.clone())
+        .populate::<Vec<_>>(args.population);
 
-    for _ in 0..args.population {
-        let pixels = std::iter::from_fn(|| Some(rng.gen_range(0..255)))
-            .take(image.width() as usize * image.height() as usize)
-            .collect::<Vec<_>>();
-
-        let image = GrayImage::from_vec(image.width(), image.height(), pixels)
-            .context("Invalid image dimensions")?;
-
-        let mut individual = Scored::new(Image::new(image), 0);
-
-        let score = scorer.score(&individual, &mut rng)?;
-
-        individual.set_fitness(score);
-        population.push(individual);
-    }
+    let population = generator.generate(&mut rng)?;
 
     let evolver = Terminal::new(
         ImageEvolver::new(scorer, args.rate, args.parallel),

--- a/examples/image/src/scorer.rs
+++ b/examples/image/src/scorer.rs
@@ -6,6 +6,7 @@ use brace_ec::core::operator::scorer::Scorer;
 
 use crate::individual::Image;
 
+#[derive(Clone)]
 pub struct ImageScorer {
     image: Image,
 }


### PR DESCRIPTION
This adds a new `ImageGenerator` that implements the new `Generator` trait to the `image` example.

The image evolver example project was created before the introduction of the `Generator` operator trait and therefore manually constructed the initial population. As this is a demonstration of the library this should instead use the new trait.

This change introduces a new `ImageGenerator` type to the image evolver example project that generates a new scored image. The implementation internally uses the `Uniform` and `Populate` generators but requires a custom `Generator` due to the format of the inner image type. This demonstrates both aspects of the library: creating new generators, and using existing generators.