### PR TITLE
Add `Individual::scored` adapter method

### DIFF
--- a/packages/brace-ec/src/core/individual/mod.rs
+++ b/packages/brace-ec/src/core/individual/mod.rs
@@ -4,6 +4,8 @@ use std::cmp::Reverse;
 
 use rand::thread_rng;
 
+use self::scored::Scored;
+
 use super::operator::mutator::Mutator;
 
 pub trait Individual {
@@ -19,6 +21,14 @@ pub trait Individual {
         Self: Sized,
     {
         mutator.mutate(self, &mut thread_rng())
+    }
+
+    fn scored<S>(self) -> Scored<Self, S>
+    where
+        S: Default,
+        Self: Sized,
+    {
+        Scored::from(self)
     }
 }
 

--- a/packages/brace-ec/src/core/individual/scored.rs
+++ b/packages/brace-ec/src/core/individual/scored.rs
@@ -69,14 +69,28 @@ mod tests {
 
     #[test]
     fn test_individual() {
-        let mut individual = Scored::<_, i32>::from([1, 0]);
+        let mut a = Scored::<_, i32>::from([1, 0]);
+        let mut b = [1, 0].scored();
+        let mut c = [1, 0].scored::<u8>();
 
-        assert_eq!(individual.genome(), [1, 0]);
-        assert_eq!(individual.fitness(), 0);
+        assert_eq!(a.genome(), [1, 0]);
+        assert_eq!(b.genome(), [1, 0]);
+        assert_eq!(c.genome(), [1, 0]);
 
-        individual.score = 10;
+        assert_eq!(a.fitness(), 0);
+        assert_eq!(b.fitness(), 0);
+        assert_eq!(c.fitness(), 0);
 
-        assert_eq!(individual.genome(), [1, 0]);
-        assert_eq!(individual.fitness(), 10);
+        a.score = 10;
+        b.score = 10;
+        c.score = 10;
+
+        assert_eq!(a.genome(), [1, 0]);
+        assert_eq!(b.genome(), [1, 0]);
+        assert_eq!(c.genome(), [1, 0]);
+
+        assert_eq!(a.fitness(), 10);
+        assert_eq!(b.fitness(), 10);
+        assert_eq!(c.fitness(), 10);
     }
 }


### PR DESCRIPTION
This adds a new `scored` method on the `Individual` trait to construct a new `Scored` individual.

The `Scored` type is an individual adapter that adds a score to any individual, including those that already have a score. This allows users to specify the type of score and score individuals that do not already implement the `Fitness` trait.

This change simply adds a new `scored` adapter method that allows users to chain `.scored` on an individual to adapt it with the `Scored` type. This allows manual type annotations to be cleaner as only the one generic needs to be specified.