### PR TITLE
Add `Hiff` scorer

### DIFF
--- a/packages/brace-ec/src/linear/operator/mod.rs
+++ b/packages/brace-ec/src/linear/operator/mod.rs
@@ -1,1 +1,2 @@
 pub mod recombinator;
+pub mod scorer;

--- a/packages/brace-ec/src/linear/operator/scorer/hiff.rs
+++ b/packages/brace-ec/src/linear/operator/scorer/hiff.rs
@@ -1,0 +1,78 @@
+use std::convert::Infallible;
+use std::ops::AddAssign;
+
+use num_traits::Zero;
+
+use crate::core::fitness::Fitness;
+use crate::core::operator::scorer::Scorer;
+
+#[ghost::phantom]
+#[derive(Clone, Copy, Debug)]
+pub struct Hiff<T: Fitness>;
+
+impl<T> Hiff<T>
+where
+    T: Fitness<Value: AddAssign<usize>>,
+{
+    fn hiff(bits: &[bool], score: &mut T::Value) -> bool {
+        let len = bits.len();
+
+        if len < 2 {
+            *score += len;
+
+            true
+        } else {
+            let half = len / 2;
+            let same_lhs = Self::hiff(&bits[..half], score);
+            let same_rhs = Self::hiff(&bits[half..], score);
+            let same = same_lhs && same_rhs && bits[0] == bits[half];
+
+            *score += same.then_some(len).unwrap_or_default();
+            same
+        }
+    }
+}
+
+impl<T> Scorer<T> for Hiff<T>
+where
+    T: Fitness<Genome: AsRef<[bool]>, Value: AddAssign<usize> + Zero>,
+{
+    type Score = T::Value;
+    type Error = Infallible;
+
+    fn score<Rng>(&self, individual: &T, _: &mut Rng) -> Result<Self::Score, Self::Error>
+    where
+        Rng: rand::Rng + ?Sized,
+    {
+        let mut score = T::Value::zero();
+
+        Self::hiff(individual.genome().as_ref(), &mut score);
+
+        Ok(score)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::individual::Individual;
+    use crate::core::operator::scorer::Scorer;
+
+    use super::Hiff;
+
+    #[test]
+    fn test_score() {
+        let mut rng = rand::thread_rng();
+
+        let a = [false, false, true, false, true, true, true, true].scored::<usize>();
+        let b = [false, false, false, false, true, false, false, true].scored::<usize>();
+        let c = [false, false, false, false, false, false, false, false].scored::<usize>();
+        let d = [true, true, true, true, true, true, true, true].scored::<usize>();
+        let e = [true, false, true, false, true, false, true, false].scored::<usize>();
+
+        assert_eq!(Hiff.score(&a, &mut rng).unwrap(), 18);
+        assert_eq!(Hiff.score(&b, &mut rng).unwrap(), 16);
+        assert_eq!(Hiff.score(&c, &mut rng).unwrap(), 32);
+        assert_eq!(Hiff.score(&d, &mut rng).unwrap(), 32);
+        assert_eq!(Hiff.score(&e, &mut rng).unwrap(), 8);
+    }
+}

--- a/packages/brace-ec/src/linear/operator/scorer/mod.rs
+++ b/packages/brace-ec/src/linear/operator/scorer/mod.rs
@@ -1,0 +1,1 @@
+pub mod hiff;


### PR DESCRIPTION
This adds a new `Hiff` scorer under the `linear` module.

The project currently has many operators but very few of those are scorers. The Hierarchical-If-and-only-If (H-IFF) function is a good candidate to implement because it is fairly simple and works on linear types such as bitstrings. This will allow new examples to be constructed that demonstrate how the project can be used.

This change simply adds a new `Hiff` scorer. This is defined under the `linear` module but does not make use of the `Chromosome` trait. The implementation uses the `AddAssign` and `Zero` trait bounds which currently supports scoring with a `usize` but this does not rule out introducing a new score type that keeps track of the entire results. The intention was to not store any intermediate results or allocate if not necessary.