### PR TITLE
Add `Limit` evolver adapter

### DIFF
--- a/packages/brace-ec/src/core/operator/evolver/limit.rs
+++ b/packages/brace-ec/src/core/operator/evolver/limit.rs
@@ -1,0 +1,75 @@
+use crate::core::generation::Generation;
+
+use super::Evolver;
+
+pub struct Limit<G, T>
+where
+    G: Generation,
+    T: Evolver<G>,
+{
+    evolver: T,
+    generation: G::Id,
+}
+
+impl<G, T> Limit<G, T>
+where
+    G: Generation,
+    T: Evolver<G>,
+{
+    pub fn new(evolver: T, generation: G::Id) -> Self {
+        Self {
+            evolver,
+            generation,
+        }
+    }
+}
+
+impl<G, T> Evolver<G> for Limit<G, T>
+where
+    G: Generation<Id: Ord>,
+    T: Evolver<G>,
+{
+    type Error = T::Error;
+
+    fn evolve<Rng>(&self, generation: G, rng: &mut Rng) -> Result<G, Self::Error>
+    where
+        Rng: rand::Rng + ?Sized,
+    {
+        if generation.id() >= &self.generation {
+            return Ok(generation);
+        }
+
+        self.evolver.evolve(generation, rng)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::operator::evolver::Evolver;
+    use crate::core::operator::selector::best::Best;
+    use crate::core::operator::selector::Selector;
+
+    #[test]
+    fn test_evolve() {
+        let mut rng = rand::thread_rng();
+
+        let a = Best
+            .fill()
+            .evolver()
+            .limit(10)
+            .repeat(20)
+            .evolve((0, [1, 2, 3]), &mut rng)
+            .unwrap();
+        let b = Best
+            .fill()
+            .evolver()
+            .repeat(3)
+            .limit(10)
+            .repeat(20)
+            .evolve((0, [1, 2, 3]), &mut rng)
+            .unwrap();
+
+        assert_eq!(a, (10, [3; 3]));
+        assert_eq!(b, (12, [3; 3]));
+    }
+}

--- a/packages/brace-ec/src/core/operator/evolver/mod.rs
+++ b/packages/brace-ec/src/core/operator/evolver/mod.rs
@@ -1,8 +1,11 @@
+pub mod limit;
 pub mod select;
 
 use crate::core::fitness::{Fitness, FitnessMut};
 use crate::core::generation::Generation;
 use crate::core::population::Population;
+
+use self::limit::Limit;
 
 use super::inspect::Inspect;
 use super::repeat::Repeat;
@@ -52,6 +55,10 @@ where
 
     fn repeat(self, count: usize) -> Repeat<Self> {
         Repeat::new(self, count)
+    }
+
+    fn limit(self, generation: G::Id) -> Limit<G, Self> {
+        Limit::new(self, generation)
     }
 
     fn inspect<F>(self, inspector: F) -> Inspect<Self, F>


### PR DESCRIPTION
This adds a new `Limit` evolver adapter.

The `Repeat` operator adapter adapts an evolver by repeating it a certain number of times and the `Terminal` evolver continues evolving until the application is stopped. However, in evolutionary computation it may be desired to stop when a certain threshold is met. This can be a duration, score or a number of generations. These should be incorporated into the project as new operators.

This change introduces the `Limit` evolver adapter that takes a generation identifier and stops evolving once it has reached that identifier. This is not a perfect solution as it has no control over the interior evolver and so it is possible for it to exceed the given generation. This is covered in the tests by using the `Repeat` evolver. Depending on where in the operator the pipeline it is used it may stop at the desired point or overshoot.