### PR TITLE
Redesign `Fitness` traits to return references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,7 @@ name = "brace-ec"
 version = "0.0.0"
 dependencies = [
  "array-util",
+ "bytemuck",
  "ghost",
  "itertools 0.14.0",
  "num-traits",

--- a/examples/image/src/evolver.rs
+++ b/examples/image/src/evolver.rs
@@ -33,7 +33,7 @@ impl Evolver<(u64, Vec<Scored<Image, u64>>)> for ImageEvolver {
     {
         let mut population = self.selector.select(generation.population(), rng)?;
 
-        population.sort_by_key(|individual| individual.fitness());
+        population.sort_by_key(|individual| *individual.fitness());
 
         generation.0 += 1;
         generation.1 = population;

--- a/packages/brace-ec/Cargo.toml
+++ b/packages/brace-ec/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 
 [dependencies]
 array-util = "1.0.2"
+bytemuck = { version = "1.21.0", features = ["transparentwrapper_extra"] }
 ghost = "0.1.18"
 itertools = "0.14.0"
 num-traits = "0.2.19"

--- a/packages/brace-ec/src/core/fitness.rs
+++ b/packages/brace-ec/src/core/fitness.rs
@@ -1,5 +1,6 @@
 use std::cmp::Reverse;
 
+use bytemuck::TransparentWrapper;
 use ordered_float::OrderedFloat;
 
 use super::individual::Individual;
@@ -7,7 +8,7 @@ use super::individual::Individual;
 pub trait Fitness: Individual {
     type Value: Ord;
 
-    fn fitness(&self) -> Self::Value;
+    fn fitness(&self) -> &Self::Value;
 }
 
 impl<T> Fitness for Reverse<T>
@@ -16,24 +17,24 @@ where
 {
     type Value = Reverse<T::Value>;
 
-    fn fitness(&self) -> Self::Value {
-        Reverse(self.0.fitness())
+    fn fitness(&self) -> &Self::Value {
+        Reverse::wrap_ref(self.0.fitness())
     }
 }
 
 impl Fitness for f32 {
     type Value = OrderedFloat<Self>;
 
-    fn fitness(&self) -> Self::Value {
-        OrderedFloat(*self)
+    fn fitness(&self) -> &Self::Value {
+        self.into()
     }
 }
 
 impl Fitness for f64 {
     type Value = OrderedFloat<Self>;
 
-    fn fitness(&self) -> Self::Value {
-        OrderedFloat(*self)
+    fn fitness(&self) -> &Self::Value {
+        self.into()
     }
 }
 
@@ -42,8 +43,8 @@ macro_rules! impl_fitness {
         $(impl Fitness for $type {
             type Value = Self;
 
-            fn fitness(&self) -> Self::Value {
-                *self
+            fn fitness(&self) -> &Self::Value {
+                self
             }
         })+
     };
@@ -53,7 +54,11 @@ impl_fitness!(u8, u16, u32, u64, u128, usize);
 impl_fitness!(i8, i16, i32, i64, i128, isize);
 
 pub trait FitnessMut: Fitness {
-    fn set_fitness(&mut self, fitness: Self::Value);
+    fn fitness_mut(&mut self) -> &mut Self::Value;
+
+    fn set_fitness(&mut self, fitness: Self::Value) {
+        *self.fitness_mut() = fitness;
+    }
 
     fn with_fitness(mut self, fitness: Self::Value) -> Self
     where
@@ -79,9 +84,9 @@ mod tests {
         let c = Reverse(50_u64);
         let d = 1.5;
 
-        assert_eq!(a.fitness(), 10);
-        assert_eq!(b.fitness(), 100);
-        assert_eq!(c.fitness(), Reverse(50));
-        assert_eq!(d.fitness(), OrderedFloat(1.5));
+        assert_eq!(*a.fitness(), 10);
+        assert_eq!(*b.fitness(), 100);
+        assert_eq!(*c.fitness(), Reverse(50));
+        assert_eq!(*d.fitness(), OrderedFloat(1.5));
     }
 }

--- a/packages/brace-ec/src/core/individual/scored.rs
+++ b/packages/brace-ec/src/core/individual/scored.rs
@@ -32,22 +32,22 @@ where
 impl<T, S> Fitness for Scored<T, S>
 where
     T: Individual,
-    S: Ord + Clone,
+    S: Ord,
 {
     type Value = S;
 
-    fn fitness(&self) -> Self::Value {
-        self.score.clone()
+    fn fitness(&self) -> &Self::Value {
+        &self.score
     }
 }
 
 impl<T, S> FitnessMut for Scored<T, S>
 where
     T: Individual,
-    S: Ord + Clone,
+    S: Ord,
 {
-    fn set_fitness(&mut self, fitness: Self::Value) {
-        self.score = fitness;
+    fn fitness_mut(&mut self) -> &mut Self::Value {
+        &mut self.score
     }
 }
 
@@ -77,9 +77,9 @@ mod tests {
         assert_eq!(b.genome(), [1, 0]);
         assert_eq!(c.genome(), [1, 0]);
 
-        assert_eq!(a.fitness(), 0);
-        assert_eq!(b.fitness(), 0);
-        assert_eq!(c.fitness(), 0);
+        assert_eq!(*a.fitness(), 0);
+        assert_eq!(*b.fitness(), 0);
+        assert_eq!(*c.fitness(), 0);
 
         a.score = 10;
         b.score = 10;
@@ -89,8 +89,8 @@ mod tests {
         assert_eq!(b.genome(), [1, 0]);
         assert_eq!(c.genome(), [1, 0]);
 
-        assert_eq!(a.fitness(), 10);
-        assert_eq!(b.fitness(), 10);
-        assert_eq!(c.fitness(), 10);
+        assert_eq!(*a.fitness(), 10);
+        assert_eq!(*b.fitness(), 10);
+        assert_eq!(*c.fitness(), 10);
     }
 }


### PR DESCRIPTION
This redesigns the `Fitness` and `FitnessMut` traits to return a reference instead of an owned value.

The `Fitness` trait currently returns an owned value and while this makes sense for returning a computed fitness the reality is that a cached fitness is far more useful due to the `Scorer` trait and `Scored` individual adapter. The `FitnessMut` trait, due to how the `Fitness` trait works, only supports the ability to set a new score and not update an existing one. There are also a number of operators that expect the fitness to be a collection of values instead of a single value and that would mean cloning and allocating which is not ideal for code that needs to be performant.

This change updates the `Fitness::fitness` method to now return a reference to the value. This unfortunately rules out individuals that compute their own score when the method is called but should still allow individuals that compute the score on construction. The `FitnessMut` trait now has a `fitness_mut` method that must be implemented, with the `set_fitness` now having a default implementation. Finally, the `Scored` individual adapter no longer needs the score to implement `Clone` and that should allow collections such as `Vec` to be used more efficiently.

The implementation of `Fitness` for `Reverse` required the addition of the `bytemuck` crate. This crate is already in the dependency tree so it shouldn't adversely affect build times. This was necessary to convert a reference of `T` to a reference of `Reverse<T>` without manually adding unsafe code. Although the `ordered-float` crate has an optional `bytemuck` dependency it does include its own unsafe conversion for the `OrderedFloat` type. An alternative would have been the more lightweight `ref-cast` crate but it does not include implementations for the standard types. It could potentially be used if the `Reverse` and `OrderedFloat` types were replaced with a new internal implementation.