### PR TITLE
Add `Reversed` individual adapter

### DIFF
--- a/packages/brace-ec/src/core/fitness.rs
+++ b/packages/brace-ec/src/core/fitness.rs
@@ -1,6 +1,3 @@
-use std::cmp::Reverse;
-
-use bytemuck::TransparentWrapper;
 use ordered_float::OrderedFloat;
 
 use super::individual::Individual;
@@ -9,17 +6,6 @@ pub trait Fitness: Individual {
     type Value: Ord;
 
     fn fitness(&self) -> &Self::Value;
-}
-
-impl<T> Fitness for Reverse<T>
-where
-    T: Fitness,
-{
-    type Value = Reverse<T::Value>;
-
-    fn fitness(&self) -> &Self::Value {
-        Reverse::wrap_ref(self.0.fitness())
-    }
 }
 
 impl Fitness for f32 {
@@ -71,8 +57,6 @@ pub trait FitnessMut: Fitness {
 
 #[cfg(test)]
 mod tests {
-    use std::cmp::Reverse;
-
     use ordered_float::OrderedFloat;
 
     use super::Fitness;
@@ -81,12 +65,10 @@ mod tests {
     fn test_fitness() {
         let a = 10_u8;
         let b = 100_i32;
-        let c = Reverse(50_u64);
-        let d = 1.5;
+        let c = 1.5;
 
         assert_eq!(*a.fitness(), 10);
         assert_eq!(*b.fitness(), 100);
-        assert_eq!(*c.fitness(), Reverse(50));
-        assert_eq!(*d.fitness(), OrderedFloat(1.5));
+        assert_eq!(*c.fitness(), OrderedFloat(1.5));
     }
 }

--- a/packages/brace-ec/src/core/individual/mod.rs
+++ b/packages/brace-ec/src/core/individual/mod.rs
@@ -1,11 +1,12 @@
+pub mod reversed;
 pub mod scored;
-
-use std::cmp::Reverse;
 
 use rand::thread_rng;
 
+use self::reversed::Reversed;
 use self::scored::Scored;
 
+use super::fitness::Fitness;
 use super::operator::mutator::Mutator;
 
 pub trait Individual {
@@ -30,6 +31,13 @@ pub trait Individual {
     {
         Scored::from(self)
     }
+
+    fn reversed(self) -> Reversed<Self>
+    where
+        Self: Fitness + Sized,
+    {
+        Reversed::new(self)
+    }
 }
 
 impl<T, const N: usize> Individual for [T; N] {
@@ -53,21 +61,6 @@ impl<T> Individual for Vec<T> {
 
     fn genome_mut(&mut self) -> &mut Self::Genome {
         self
-    }
-}
-
-impl<T> Individual for Reverse<T>
-where
-    T: Individual,
-{
-    type Genome = T::Genome;
-
-    fn genome(&self) -> &Self::Genome {
-        self.0.genome()
-    }
-
-    fn genome_mut(&mut self) -> &mut Self::Genome {
-        self.0.genome_mut()
     }
 }
 

--- a/packages/brace-ec/src/core/individual/reversed.rs
+++ b/packages/brace-ec/src/core/individual/reversed.rs
@@ -1,0 +1,79 @@
+use std::cmp::Reverse;
+
+use bytemuck::TransparentWrapper;
+
+use crate::core::fitness::{Fitness, FitnessMut};
+
+use super::Individual;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Reversed<T> {
+    pub individual: T,
+}
+
+impl<T> Reversed<T> {
+    pub fn new(individual: T) -> Self {
+        Self { individual }
+    }
+}
+
+impl<T> Individual for Reversed<T>
+where
+    T: Individual,
+{
+    type Genome = T::Genome;
+
+    fn genome(&self) -> &Self::Genome {
+        self.individual.genome()
+    }
+
+    fn genome_mut(&mut self) -> &mut Self::Genome {
+        self.individual.genome_mut()
+    }
+}
+
+impl<T> Fitness for Reversed<T>
+where
+    T: Fitness,
+{
+    type Value = Reverse<T::Value>;
+
+    fn fitness(&self) -> &Self::Value {
+        Reverse::wrap_ref(self.individual.fitness())
+    }
+}
+
+impl<T> FitnessMut for Reversed<T>
+where
+    T: FitnessMut,
+{
+    fn fitness_mut(&mut self) -> &mut Self::Value {
+        Reverse::wrap_mut(self.individual.fitness_mut())
+    }
+}
+
+impl<T> From<T> for Reversed<T> {
+    fn from(individual: T) -> Self {
+        Self::new(individual)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::fitness::Fitness;
+    use crate::core::individual::scored::Scored;
+    use crate::core::individual::Individual;
+
+    use super::Reversed;
+
+    #[test]
+    fn test_individual() {
+        assert!(0.fitness() < 100.fitness());
+        assert!(0.reversed().fitness() > 100.reversed().fitness());
+
+        let a = Reversed::new(Scored::new([1, 2, 3], 3));
+        let b = Reversed::new(Scored::new([4, 5, 6], 6));
+
+        assert!(a.fitness() > b.fitness());
+    }
+}

--- a/packages/brace-ec/src/core/operator/selector/best.rs
+++ b/packages/brace-ec/src/core/operator/selector/best.rs
@@ -36,9 +36,9 @@ pub enum BestError {
 
 #[cfg(test)]
 mod tests {
-    use std::cmp::Reverse;
-
+    use crate::core::individual::reversed::Reversed;
     use crate::core::individual::scored::Scored;
+    use crate::core::individual::Individual;
     use crate::core::population::Population;
 
     use super::Best;
@@ -50,10 +50,16 @@ mod tests {
 
         assert_eq!(individual, 4);
 
-        let population = [Reverse(0), Reverse(1), Reverse(2), Reverse(3), Reverse(4)];
+        let population = [
+            Reversed::new(0),
+            Reversed::new(1),
+            Reversed::new(2),
+            Reversed::new(3),
+            Reversed::new(4),
+        ];
         let individual = population.select(Best).unwrap()[0];
 
-        assert_eq!(individual, Reverse(0));
+        assert_eq!(individual, Reversed::new(0));
 
         let population = [Scored::new(0, 0), Scored::new(10, 10), Scored::new(20, 5)];
         let individual = population.select(Best).unwrap()[0];
@@ -61,12 +67,12 @@ mod tests {
         assert_eq!(individual, Scored::new(10, 10));
 
         let population = [
-            Reverse(Scored::new(30, 3)),
-            Reverse(Scored::new(10, 10)),
-            Reverse(Scored::new(20, 5)),
+            Scored::new(30, 3).reversed(),
+            Scored::new(10, 10).reversed(),
+            Scored::new(20, 5).reversed(),
         ];
         let individual = population.select(Best).unwrap()[0];
 
-        assert_eq!(individual, Reverse(Scored::new(30, 3)));
+        assert_eq!(individual, Reversed::new(Scored::new(30, 3)));
     }
 }

--- a/packages/brace-ec/src/core/operator/selector/worst.rs
+++ b/packages/brace-ec/src/core/operator/selector/worst.rs
@@ -36,9 +36,9 @@ pub enum WorstError {
 
 #[cfg(test)]
 mod tests {
-    use std::cmp::Reverse;
-
+    use crate::core::individual::reversed::Reversed;
     use crate::core::individual::scored::Scored;
+    use crate::core::individual::Individual;
     use crate::core::population::Population;
 
     use super::Worst;
@@ -50,10 +50,16 @@ mod tests {
 
         assert_eq!(individual, 0);
 
-        let population = [Reverse(0), Reverse(1), Reverse(2), Reverse(3), Reverse(4)];
+        let population = [
+            Reversed::new(0),
+            Reversed::new(1),
+            Reversed::new(2),
+            Reversed::new(3),
+            Reversed::new(4),
+        ];
         let individual = population.select(Worst).unwrap()[0];
 
-        assert_eq!(individual, Reverse(4));
+        assert_eq!(individual, Reversed::new(4));
 
         let population = [Scored::new(0, 0), Scored::new(10, 10), Scored::new(20, 5)];
         let individual = population.select(Worst).unwrap()[0];
@@ -61,12 +67,12 @@ mod tests {
         assert_eq!(individual, Scored::new(0, 0));
 
         let population = [
-            Reverse(Scored::new(30, 3)),
-            Reverse(Scored::new(10, 10)),
-            Reverse(Scored::new(20, 5)),
+            Scored::new(30, 3).reversed(),
+            Scored::new(10, 10).reversed(),
+            Scored::new(20, 5).reversed(),
         ];
         let individual = population.select(Worst).unwrap()[0];
 
-        assert_eq!(individual, Reverse(Scored::new(10, 10)));
+        assert_eq!(individual, Reversed::new(Scored::new(10, 10)));
     }
 }


### PR DESCRIPTION
This adds a new `Reversed` individual adapter that reverses the score.

The `Individual` and `Fitness` traits were implemented for the `Reverse` type in the standard library in #30 but this was not ideal as it reversed the ordering of the individual itself and not just the score.

This change removes the previous implementation for `Reverse` and introduces a new `Reversed` individual adapter that keeps the adapter naming convention of `Scored`. This still uses the `Reverse` type but only as the fitness value and not the individual. This also includes a `reversed` method on the `Individual` trait to simplify the construction of a reversed individual.