### PR TITLE
Move `Nil` to `fitness` module

### DIFF
--- a/examples/image/src/individual.rs
+++ b/examples/image/src/individual.rs
@@ -1,4 +1,5 @@
-use brace_ec::core::individual::{Individual, Nil};
+use brace_ec::core::fitness::nil::Nil;
+use brace_ec::core::individual::Individual;
 use image::GrayImage;
 
 #[derive(Clone)]

--- a/packages/brace-ec/src/core/fitness/mod.rs
+++ b/packages/brace-ec/src/core/fitness/mod.rs
@@ -1,0 +1,1 @@
+pub mod nil;

--- a/packages/brace-ec/src/core/fitness/nil.rs
+++ b/packages/brace-ec/src/core/fitness/nil.rs
@@ -1,0 +1,19 @@
+use bytemuck::TransparentWrapper;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, TransparentWrapper)]
+#[repr(transparent)]
+pub struct Nil([(); 0]);
+
+impl Nil {
+    pub fn new() -> Self {
+        Self([])
+    }
+
+    pub fn r#ref() -> &'static Self {
+        Self::wrap_ref(&[])
+    }
+
+    pub fn r#mut() -> &'static mut Self {
+        Self::wrap_mut(&mut [])
+    }
+}

--- a/packages/brace-ec/src/core/individual/mod.rs
+++ b/packages/brace-ec/src/core/individual/mod.rs
@@ -1,12 +1,12 @@
 pub mod reversed;
 pub mod scored;
 
-use bytemuck::TransparentWrapper;
 use ordered_float::OrderedFloat;
 
 use self::reversed::Reversed;
 use self::scored::Scored;
 
+use super::fitness::nil::Nil;
 use super::operator::mutator::Mutator;
 
 pub trait Individual {
@@ -170,30 +170,11 @@ impl_individual!(u8, u16, u32, u64, u128, usize);
 impl_individual!(i8, i16, i32, i64, i128, isize);
 impl_individual!(char, bool);
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, TransparentWrapper)]
-#[repr(transparent)]
-pub struct Nil([(); 0]);
-
-impl Nil {
-    /// Creates a new `Nil` score.
-    pub fn new() -> Self {
-        Self([])
-    }
-
-    /// Creates a new `Nil` score shared reference
-    pub fn r#ref() -> &'static Self {
-        Self::wrap_ref(&[])
-    }
-
-    /// Creates a new `Nil` score exclusive reference.
-    pub fn r#mut() -> &'static mut Self {
-        Self::wrap_mut(&mut [])
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{Individual, Nil};
+    use crate::core::fitness::nil::Nil;
+
+    use super::Individual;
 
     fn erase<G: ?Sized, I: Individual<Genome = G>>(
         individual: I,

--- a/packages/brace-ec/src/core/mod.rs
+++ b/packages/brace-ec/src/core/mod.rs
@@ -1,3 +1,4 @@
+pub mod fitness;
 pub mod generation;
 pub mod individual;
 pub mod operator;


### PR DESCRIPTION
This moves the `Nil` type to a new `fitness` module.

The previous update #97 merged the `Fitness` and `FitnessMut` traits into the `Individual` trait. In doing so it introduced the `Nil` type to be used as a fitness for types with no obvious fitness value. This was included in the `individual` module but there is a desire to include new fitness types now that the name has been freed up.

This change simply moves the `Nil` type to the `core::fitness::nil` module such that other types of fitness values and a new `Fitness` trait can be introduced.