### PR TITLE
Add `Fitness` trait

### DIFF
--- a/packages/brace-ec/src/core/fitness/mod.rs
+++ b/packages/brace-ec/src/core/fitness/mod.rs
@@ -1,1 +1,53 @@
 pub mod nil;
+
+use std::cmp::Reverse;
+
+use num_traits::Zero;
+use ordered_float::{FloatCore, OrderedFloat};
+
+pub trait Fitness: Ord {
+    fn nil() -> Self;
+}
+
+impl<T> Fitness for OrderedFloat<T>
+where
+    T: FloatCore,
+{
+    fn nil() -> Self {
+        Zero::zero()
+    }
+}
+
+impl<T> Fitness for Reverse<T>
+where
+    T: Fitness,
+{
+    fn nil() -> Self {
+        Self(T::nil())
+    }
+}
+
+macro_rules! impl_fitness_zero {
+    ($($type:path),+) => {
+        $(impl Fitness for $type {
+            fn nil() -> Self {
+                Zero::zero()
+            }
+        })+
+    };
+}
+
+impl_fitness_zero!(u8, u16, u32, u64, u128, usize);
+impl_fitness_zero!(i8, i16, i32, i64, i128, isize);
+
+macro_rules! impl_fitness_default {
+    ($($type:path),+) => {
+        $(impl Fitness for $type {
+            fn nil() -> Self {
+                Default::default()
+            }
+        })+
+    };
+}
+
+impl_fitness_default!(char, bool);

--- a/packages/brace-ec/src/core/fitness/nil.rs
+++ b/packages/brace-ec/src/core/fitness/nil.rs
@@ -1,5 +1,7 @@
 use bytemuck::TransparentWrapper;
 
+use super::Fitness;
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, TransparentWrapper)]
 #[repr(transparent)]
 pub struct Nil([(); 0]);
@@ -15,5 +17,11 @@ impl Nil {
 
     pub fn r#mut() -> &'static mut Self {
         Self::wrap_mut(&mut [])
+    }
+}
+
+impl Fitness for Nil {
+    fn nil() -> Self {
+        Self::new()
     }
 }

--- a/packages/brace-ec/src/core/individual/mod.rs
+++ b/packages/brace-ec/src/core/individual/mod.rs
@@ -7,11 +7,12 @@ use self::reversed::Reversed;
 use self::scored::Scored;
 
 use super::fitness::nil::Nil;
+use super::fitness::Fitness;
 use super::operator::mutator::Mutator;
 
 pub trait Individual {
     type Genome: ?Sized;
-    type Fitness: Ord;
+    type Fitness: Fitness;
 
     fn genome(&self) -> &Self::Genome;
 
@@ -43,7 +44,7 @@ pub trait Individual {
 
     fn scored<S>(self) -> Scored<Self, S>
     where
-        S: Default,
+        S: Fitness,
         Self: Sized,
     {
         Scored::from(self)

--- a/packages/brace-ec/src/core/individual/scored.rs
+++ b/packages/brace-ec/src/core/individual/scored.rs
@@ -1,3 +1,5 @@
+use crate::core::fitness::Fitness;
+
 use super::Individual;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -15,7 +17,7 @@ impl<T, S> Scored<T, S> {
 impl<T, S> Individual for Scored<T, S>
 where
     T: Individual,
-    S: Ord,
+    S: Fitness,
 {
     type Genome = T::Genome;
     type Fitness = S;
@@ -39,10 +41,10 @@ where
 
 impl<T, S> From<T> for Scored<T, S>
 where
-    S: Default,
+    S: Fitness,
 {
     fn from(individual: T) -> Self {
-        Self::new(individual, S::default())
+        Self::new(individual, S::nil())
     }
 }
 


### PR DESCRIPTION
This adds a new `Fitness` trait that is different to the previous `Fitness` trait.

The `Fitness` trait was originally introduced in #29 as an extension to the `Individual` trait to provide a new `fitness` method. The trait was named after the method but didn't quite fit the naming conventions in this crate or the wider Rust ecosystem. At the time it seemed preferable to `WithFitness`, `Fit`, `Score`, or any other option. Now that the `Fitness` trait has been merged with the `Individual` trait in #97 the name is free to be repurposed.

This change introduces a _new_ `Fitness` trait that represents the value instead of an individual with a fitness. The trait has a single method `nil` which was chosen based on the `Nil` fitness from #98 and to avoid conflicting with the `zero` method from the `Zero` trait. Unfortunately types such as `Reverse` do not implement `Zero` and it required `Add` so that was not an option. The `Default` trait was ruled out because that may imply a non-zero value. However, nil may suggest no value rather than a zero value so there is no clear option. At the very least the method justifies the existence of the trait.

This also updates various trait bounds to replace `Default` with `Fitness` and updates the associated `Fitness` in the `Individual` trait to add a new bound.