### PR TITLE
Add `Summed` fitness

### DIFF
--- a/packages/brace-ec/src/core/fitness/mod.rs
+++ b/packages/brace-ec/src/core/fitness/mod.rs
@@ -1,4 +1,5 @@
 pub mod nil;
+pub mod summed;
 
 use std::cmp::Reverse;
 

--- a/packages/brace-ec/src/core/fitness/summed.rs
+++ b/packages/brace-ec/src/core/fitness/summed.rs
@@ -1,0 +1,186 @@
+use std::cmp::Ordering;
+use std::fmt::{self, Debug};
+use std::iter::Sum;
+use std::ops::{Add, AddAssign, Index};
+
+use crate::util::iter::Iterable;
+
+use super::Fitness;
+
+pub struct Summed<T>
+where
+    T: Iterable,
+{
+    value: T,
+    total: T::Item,
+}
+
+impl<T> Summed<T>
+where
+    T: Iterable<Item: for<'a> Sum<&'a T::Item>>,
+{
+    pub fn new(value: T) -> Self {
+        Self {
+            total: value.iter().sum(),
+            value,
+        }
+    }
+}
+
+impl<T> Summed<T>
+where
+    T: Iterable,
+{
+    pub fn value(&self) -> &T {
+        &self.value
+    }
+
+    pub fn total(&self) -> &T::Item {
+        &self.total
+    }
+}
+
+impl<T> Fitness for Summed<T>
+where
+    T: Iterable<Item: Ord + for<'a> Sum<&'a T::Item>> + Default,
+{
+    fn nil() -> Self {
+        Self::new(T::default())
+    }
+}
+
+impl<T> Default for Summed<T>
+where
+    T: Iterable<Item: for<'a> Sum<&'a T::Item>> + Default,
+{
+    fn default() -> Self {
+        Self::new(T::default())
+    }
+}
+
+impl<T> Clone for Summed<T>
+where
+    T: Iterable<Item: Clone> + Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            value: self.value.clone(),
+            total: self.total.clone(),
+        }
+    }
+}
+
+impl<T> Debug for Summed<T>
+where
+    T: Iterable<Item: Debug> + Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Summed")
+            .field("value", &self.value)
+            .field("total", &self.total)
+            .finish()
+    }
+}
+
+impl<T> PartialEq for Summed<T>
+where
+    T: Iterable<Item: PartialEq>,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.total == other.total
+    }
+}
+
+impl<T> Eq for Summed<T> where T: Iterable<Item: Eq> {}
+
+impl<T> PartialOrd for Summed<T>
+where
+    T: Iterable<Item: PartialOrd>,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.total.partial_cmp(&other.total)
+    }
+}
+
+impl<T> Ord for Summed<T>
+where
+    T: Iterable<Item: Ord>,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.total.cmp(&other.total)
+    }
+}
+
+impl<T> Add<T::Item> for Summed<T>
+where
+    T: Iterable<Item: AddAssign + Clone> + Extend<T::Item>,
+{
+    type Output = Self;
+
+    fn add(mut self, rhs: T::Item) -> Self::Output {
+        self += rhs;
+        self
+    }
+}
+
+impl<T> AddAssign<T::Item> for Summed<T>
+where
+    T: Iterable<Item: AddAssign + Clone> + Extend<T::Item>,
+{
+    fn add_assign(&mut self, rhs: T::Item) {
+        self.total += rhs.clone();
+        self.value.extend(Some(rhs));
+    }
+}
+
+impl<I, T> Index<I> for Summed<T>
+where
+    T: Iterable + Index<I>,
+{
+    type Output = T::Output;
+
+    fn index(&self, index: I) -> &Self::Output {
+        self.value.index(index)
+    }
+}
+
+impl<T> Iterable for Summed<T>
+where
+    T: Iterable,
+{
+    type Item = T::Item;
+    type Iter<'a>
+        = T::Iter<'a>
+    where
+        Self: 'a;
+
+    fn iter(&self) -> Self::Iter<'_> {
+        self.value.iter()
+    }
+}
+
+impl<T> FromIterator<T::Item> for Summed<T>
+where
+    T: FromIterator<T::Item> + Iterable<Item: for<'a> Sum<&'a T::Item>>,
+{
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = T::Item>,
+    {
+        let value = iter.into_iter().collect::<T>();
+
+        Self {
+            total: value.iter().sum(),
+            value,
+        }
+    }
+}
+
+impl<T> From<T> for Summed<T>
+where
+    T: Iterable<Item: for<'a> Sum<&'a T::Item>>,
+{
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}


### PR DESCRIPTION
This adds a new `Summed` fitness that provides an ordering to an iterable collection.

There is a need to support fitness values that represent a collection of scores for new selectors such as `Lexicase` and in existing scorers such as `Hiff`. Although `Vec` implements `Ord` it does so lexicographically which is not suitable for use with the `Hiff` scorer. Instead, there should be a way to order a fitness by the sum of values.

This change introduces a new `Summed` fitness that works with collections such as `Vec` to produce a `Summed<Vec<T>>` where the ordering is based on the total of summed `T`. This includes a number of useful trait implementations such as `Index` and `AddAssign`. The latter can be used in combination with the `Hiff` scorer to add a value to both the total and collection at the same time. The former may be useful for an implementation of `Lexicase` selection.