### PR TITLE
Add support for unsized populations in `Generate`

### DIFF
--- a/packages/brace-ec/src/core/operator/generator/mod.rs
+++ b/packages/brace-ec/src/core/operator/generator/mod.rs
@@ -44,7 +44,7 @@ pub trait Generator<T>: Sized {
 
     fn selector<P>(self) -> Generate<Self, P>
     where
-        P: Population<Individual = T>,
+        P: Population<Individual = T> + ?Sized,
     {
         Generate::new(self)
     }

--- a/packages/brace-ec/src/core/operator/selector/generate.rs
+++ b/packages/brace-ec/src/core/operator/selector/generate.rs
@@ -5,12 +5,18 @@ use crate::core::population::Population;
 
 use super::Selector;
 
-pub struct Generate<T, P> {
+pub struct Generate<T, P>
+where
+    P: ?Sized,
+{
     generator: T,
     marker: PhantomData<fn() -> P>,
 }
 
-impl<T, P> Generate<T, P> {
+impl<T, P> Generate<T, P>
+where
+    P: ?Sized,
+{
     pub fn new(generator: T) -> Self {
         Self {
             generator,
@@ -21,7 +27,7 @@ impl<T, P> Generate<T, P> {
 
 impl<P, T> Selector<P> for Generate<T, P>
 where
-    P: Population,
+    P: Population + ?Sized,
     T: Generator<P::Individual>,
 {
     type Output = [P::Individual; 1];
@@ -47,8 +53,13 @@ mod tests {
 
         let a = population.select(Random::from(6..10).selector()).unwrap();
         let b = population.select(Random::from(1..2).selector()).unwrap();
+        let c = population
+            .as_slice()
+            .select(Random::from(1..2).selector())
+            .unwrap();
 
         assert!(a[0] >= 6 && a[0] < 10);
         assert_eq!(b, [1]);
+        assert_eq!(c, [1]);
     }
 }


### PR DESCRIPTION
This is a follow-up to #65 and #85 that adds support to unsized populations to the `Generate` selector.

The `Generate` selector was introduced in #85 to allow a generator to be used as a selector. However, it did not add the necessary `?Sized` bounds to support unsized populations such as slices. The generator does not actually use the population but it still needs the correct bounds to support any population.

This change simply updates the `Generate` selector and `Generator::selector` method to add the `?Sized` bound to the population. This includes an updated test to ensure that it supports slices.