### PR TITLE
Implement `Sum` for `Summed`

### DIFF
--- a/packages/brace-ec/src/core/fitness/summed.rs
+++ b/packages/brace-ec/src/core/fitness/summed.rs
@@ -133,6 +133,18 @@ where
     }
 }
 
+impl<T> Sum<T::Item> for Summed<T>
+where
+    T: FromIterator<T::Item> + Iterable<Item: for<'a> Sum<&'a T::Item>>,
+{
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = T::Item>,
+    {
+        Self::from_iter(iter)
+    }
+}
+
 impl<I, T> Index<I> for Summed<T>
 where
     T: Iterable + Index<I>,


### PR DESCRIPTION
This simply implements `Sum` for the `Summed` fitness.

The `Summed` fitness was introduced in #100 to support using collections as fitness values where the ordering is defined by the sum of the items. This included many different trait implementations but unfortunately did not include an implementation of `Sum`.

This change adds a new implementation of `Sum` to the `Summed` fitness that simply uses the `FromIterator` implementation to sum an iterator of items.