### PR TITLE
Rename `Individual::mutate` to `mutated`

### DIFF
--- a/packages/brace-ec/src/core/individual/mod.rs
+++ b/packages/brace-ec/src/core/individual/mod.rs
@@ -34,7 +34,7 @@ pub trait Individual {
         self
     }
 
-    fn mutate<M>(self, mutator: M) -> Result<Self, M::Error>
+    fn mutated<M>(self, mutator: M) -> Result<Self, M::Error>
     where
         M: Mutator<Self>,
         Self: Sized,

--- a/packages/brace-ec/src/core/operator/inspect.rs
+++ b/packages/brace-ec/src/core/operator/inspect.rs
@@ -117,7 +117,7 @@ mod tests {
 
     #[test]
     fn test_mutate() {
-        1.mutate(Add(1).inspect(|individual| assert_eq!(individual, &2)))
+        1.mutated(Add(1).inspect(|individual| assert_eq!(individual, &2)))
             .unwrap();
     }
 

--- a/packages/brace-ec/src/core/operator/mutator/noise.rs
+++ b/packages/brace-ec/src/core/operator/mutator/noise.rs
@@ -72,13 +72,13 @@ mod tests {
     #[test]
     fn test_mutate() {
         for _ in 0..1_000 {
-            let a = 150.mutate(Noise(1..11)).unwrap();
+            let a = 150.mutated(Noise(1..11)).unwrap();
 
             assert!(a != 150);
             assert!(a <= 160);
             assert!(a >= 140);
 
-            let b = 250.mutate(Noise::new(1..=10)).unwrap();
+            let b = 250.mutated(Noise::new(1..=10)).unwrap();
 
             assert!(b != 250);
             assert!(b <= 260);
@@ -86,7 +86,7 @@ mod tests {
         }
 
         for _ in 0..10 {
-            let c = 350.mutate(Noise::default()).unwrap();
+            let c = 350.mutated(Noise::default()).unwrap();
 
             assert!(c == 349 || c == 351);
         }

--- a/packages/brace-ec/src/core/operator/mutator/rate.rs
+++ b/packages/brace-ec/src/core/operator/mutator/rate.rs
@@ -40,8 +40,8 @@ mod tests {
 
     #[test]
     fn test_mutate() {
-        let a = 1.mutate(Add(1).rate(1.0)).unwrap();
-        let b = 1.mutate(Add(1).rate(0.0)).unwrap();
+        let a = 1.mutated(Add(1).rate(1.0)).unwrap();
+        let b = 1.mutated(Add(1).rate(0.0)).unwrap();
 
         assert_eq!(a, 2);
         assert_eq!(b, 1);

--- a/packages/brace-ec/src/core/operator/repeat.rs
+++ b/packages/brace-ec/src/core/operator/repeat.rs
@@ -141,9 +141,9 @@ mod tests {
 
     #[test]
     fn test_mutate() {
-        let a = 0.mutate(Add(1).repeat(0)).unwrap();
-        let b = 1.mutate(Add(1).repeat(2)).unwrap();
-        let c = 2.mutate(Add(3).repeat(3)).unwrap();
+        let a = 0.mutated(Add(1).repeat(0)).unwrap();
+        let b = 1.mutated(Add(1).repeat(2)).unwrap();
+        let c = 2.mutated(Add(3).repeat(3)).unwrap();
 
         assert_eq!(a, 0);
         assert_eq!(b, 3);

--- a/packages/brace-ec/src/core/operator/score.rs
+++ b/packages/brace-ec/src/core/operator/score.rs
@@ -248,13 +248,13 @@ mod tests {
     #[test]
     fn test_mutate() {
         let a = Scored::new(10, 0)
-            .mutate(Add(5).score(Function::new(double)))
+            .mutated(Add(5).score(Function::new(double)))
             .unwrap();
         let b = Scored::new(10, 0)
-            .mutate(Add(5).score(Function::new(triple)))
+            .mutated(Add(5).score(Function::new(triple)))
             .unwrap();
         let c = Scored::new(10, 0)
-            .mutate(Add(5).score_with(|individual: &Scored<i32, i32>| {
+            .mutated(Add(5).score_with(|individual: &Scored<i32, i32>| {
                 Ok::<_, Infallible>(individual.individual * 4)
             }))
             .unwrap();

--- a/packages/brace-ec/src/core/operator/then.rs
+++ b/packages/brace-ec/src/core/operator/then.rs
@@ -172,8 +172,8 @@ mod tests {
 
     #[test]
     fn test_mutate() {
-        let a = 0.mutate(Add(1).then(Add(2))).unwrap();
-        let b = 1.mutate(Add(2).then(Add(1))).unwrap();
+        let a = 0.mutated(Add(1).then(Add(2))).unwrap();
+        let b = 1.mutated(Add(2).then(Add(1))).unwrap();
 
         assert_eq!(a, 3);
         assert_eq!(b, 4);


### PR DESCRIPTION
This simply renames the `Individual::mutate` method to `mutate`.

The `mutate` method was added to the `Individual` trait to support mutating from the individual rather than the mutator for simplified tests and situations where constructing a random number generator is not wanted. However, the name of this method is the same name as the mutator method and it is possible for rust-analyzer to get confused when both traits are in scope. This happens even when the code builds successfully and the trait bounds are clear.

This change renames the `mutate` method in the `Individual` trait to `mutated`. This not only avoids rust-analyzer errors but also makes more sense for a method that takes a `self` receiver. This matches the `scored` and `reversed` methods which also transform the individual but instead by infallibly wrapping the type.