### PR TITLE
Rename `Population::recombine` to `recombined`

### DIFF
--- a/packages/brace-ec/src/core/operator/inspect.rs
+++ b/packages/brace-ec/src/core/operator/inspect.rs
@@ -124,7 +124,7 @@ mod tests {
     #[test]
     fn test_recombine() {
         [2, 2]
-            .recombine(Sum.inspect(|output| assert_eq!(output, &[4])))
+            .recombined(Sum.inspect(|output| assert_eq!(output, &[4])))
             .unwrap();
     }
 

--- a/packages/brace-ec/src/core/operator/repeat.rs
+++ b/packages/brace-ec/src/core/operator/repeat.rs
@@ -154,11 +154,11 @@ mod tests {
     fn test_recombine() {
         let population = [0, 1];
 
-        let a = population.recombine(Swap).unwrap();
-        let b = population.recombine(Swap.repeat(0)).unwrap();
-        let c = population.recombine(Swap.repeat(1)).unwrap();
-        let d = population.recombine(Swap.repeat(2)).unwrap();
-        let e = population.recombine(Swap.repeat(2).repeat(2)).unwrap();
+        let a = population.recombined(Swap).unwrap();
+        let b = population.recombined(Swap.repeat(0)).unwrap();
+        let c = population.recombined(Swap.repeat(1)).unwrap();
+        let d = population.recombined(Swap.repeat(2)).unwrap();
+        let e = population.recombined(Swap.repeat(2).repeat(2)).unwrap();
 
         assert_eq!(a, [1, 0]);
         assert_eq!(b, [0, 1]);

--- a/packages/brace-ec/src/core/operator/score.rs
+++ b/packages/brace-ec/src/core/operator/score.rs
@@ -269,13 +269,13 @@ mod tests {
         let population = [Scored::new(10, 0), Scored::new(20, 0)];
 
         let a = population
-            .recombine(Noop.score(Function::new(double)))
+            .recombined(Noop.score(Function::new(double)))
             .unwrap();
         let b = population
-            .recombine(Noop.score(Function::new(triple)))
+            .recombined(Noop.score(Function::new(triple)))
             .unwrap();
         let c = population
-            .recombine(Noop.score_with(|individual: &Scored<i32, i32>| {
+            .recombined(Noop.score_with(|individual: &Scored<i32, i32>| {
                 Ok::<_, Infallible>(individual.individual * 4)
             }))
             .unwrap();

--- a/packages/brace-ec/src/core/operator/then.rs
+++ b/packages/brace-ec/src/core/operator/then.rs
@@ -73,13 +73,12 @@ where
     where
         Rng: rand::Rng + ?Sized,
     {
-        // Note: Using this form because rust-analyzer gets confused.
-        Recombinator::recombine(
-            &self.rhs,
-            Recombinator::recombine(&self.lhs, parents, rng).map_err(ThenError::Left)?,
-            rng,
-        )
-        .map_err(ThenError::Right)
+        self.rhs
+            .recombine(
+                self.lhs.recombine(parents, rng).map_err(ThenError::Left)?,
+                rng,
+            )
+            .map_err(ThenError::Right)
     }
 }
 
@@ -183,9 +182,9 @@ mod tests {
     fn test_recombine() {
         let population = [0, 1];
 
-        let a = population.recombine(Swap).unwrap();
-        let b = population.recombine(Swap.then(Swap)).unwrap();
-        let c = population.recombine(Swap.then(Swap).then(Swap)).unwrap();
+        let a = population.recombined(Swap).unwrap();
+        let b = population.recombined(Swap.then(Swap)).unwrap();
+        let c = population.recombined(Swap.then(Swap).then(Swap)).unwrap();
 
         assert_eq!(a, [1, 0]);
         assert_eq!(b, [0, 1]);

--- a/packages/brace-ec/src/core/population.rs
+++ b/packages/brace-ec/src/core/population.rs
@@ -20,7 +20,7 @@ pub trait Population {
         selector.select(self, &mut rand::rng())
     }
 
-    fn recombine<R>(self, recombinator: R) -> Result<R::Output, R::Error>
+    fn recombined<R>(self, recombinator: R) -> Result<R::Output, R::Error>
     where
         R: Recombinator<Self>,
         Self: Sized,


### PR DESCRIPTION
This simply renames the `Population::recombine` method to `recombined`.

The `recombine` method was added to the `Population` trait to support recombining from the population rather than the recombinator for simplified tests and situations where constructing a random number generator is not wanted. However, the name of this method is the same name as the recombinator method and it is possible for rust-analyzer to get confused when both traits are in scope. This happens even when the code builds successfully and the trait bounds are clear.

This change renames the `recombine` method in the `Population` trait to `recombined`. This not only avoids rust-analyzer errors but also makes more sense for a method that takes a `self` receiver. This matches the naming convention of similar methods in the `Individual` trait.