### PR TITLE
Add `HillClimb` selector adapter

### DIFF
--- a/packages/brace-ec/src/core/operator/selector/hill_climb.rs
+++ b/packages/brace-ec/src/core/operator/selector/hill_climb.rs
@@ -1,0 +1,117 @@
+use thiserror::Error;
+
+use crate::core::individual::Individual;
+use crate::core::operator::mutator::Mutator;
+use crate::core::population::Population;
+
+use super::Selector;
+
+pub struct HillClimb<S, M> {
+    selector: S,
+    mutator: M,
+    iterations: usize,
+}
+
+impl<S, M> HillClimb<S, M> {
+    pub fn new(selector: S, mutator: M, iterations: usize) -> Self {
+        Self {
+            selector,
+            mutator,
+            iterations,
+        }
+    }
+}
+
+impl<P, S, M> Selector<P> for HillClimb<S, M>
+where
+    P: Population<Individual: Clone> + ?Sized,
+    S: Selector<P, Output = [P::Individual; 1]>,
+    M: Mutator<P::Individual>,
+{
+    type Output = [P::Individual; 1];
+    type Error = HillClimbError<S::Error, M::Error>;
+
+    fn select<Rng>(&self, population: &P, rng: &mut Rng) -> Result<Self::Output, Self::Error>
+    where
+        Rng: rand::Rng + ?Sized,
+    {
+        let [individual] = self
+            .selector
+            .select(population, rng)
+            .map_err(HillClimbError::Select)?;
+
+        let individual = (0..self.iterations)
+            .try_fold(individual, |prev, _| {
+                let next = self.mutator.mutate(prev.clone(), rng)?;
+
+                if next.fitness() > prev.fitness() {
+                    Ok(next)
+                } else {
+                    Ok(prev)
+                }
+            })
+            .map_err(HillClimbError::Mutate)?;
+
+        Ok([individual])
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum HillClimbError<S, M> {
+    #[error(transparent)]
+    Select(S),
+    #[error(transparent)]
+    Mutate(M),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+
+    use crate::core::operator::mutator::add::Add;
+    use crate::core::operator::mutator::Mutator;
+    use crate::core::operator::scorer::Scorer;
+    use crate::core::operator::selector::best::Best;
+    use crate::core::operator::selector::Selector;
+
+    use super::HillClimb;
+
+    struct HillScorer;
+
+    impl Scorer<i32> for HillScorer {
+        type Score = i32;
+        type Error = Infallible;
+
+        fn score<Rng>(&self, input: &i32, _: &mut Rng) -> Result<Self::Score, Self::Error>
+        where
+            Rng: rand::Rng + ?Sized,
+        {
+            match input {
+                10 => Ok(0),
+                _ => Ok(*input),
+            }
+        }
+    }
+
+    #[test]
+    fn test_select() {
+        let mut rng = rand::rng();
+
+        let a = HillClimb::new(Best, Add(1), 10)
+            .select(&[1, 2, 3, 4, 5], &mut rng)
+            .unwrap();
+        let b = Best
+            .hill_climb(Add(1), 10)
+            .select(&[1, 2, 3, 4, 5], &mut rng)
+            .unwrap();
+        let c = Best
+            .score(HillScorer)
+            .hill_climb(Add(1).score(HillScorer), 10)
+            .select(&[1, 2, 3, 4, 5], &mut rng)
+            .unwrap();
+
+        assert_eq!(a, [15]);
+        assert_eq!(b, [15]);
+        assert_eq!(c, [9]);
+    }
+}

--- a/packages/brace-ec/src/core/operator/selector/mod.rs
+++ b/packages/brace-ec/src/core/operator/selector/mod.rs
@@ -3,6 +3,7 @@ pub mod best;
 pub mod fill;
 pub mod first;
 pub mod generate;
+pub mod hill_climb;
 pub mod lexicase;
 pub mod mutate;
 pub mod random;
@@ -18,6 +19,7 @@ use crate::core::population::Population;
 
 use self::and::And;
 use self::fill::{Fill, ParFill};
+use self::hill_climb::HillClimb;
 use self::mutate::Mutate;
 use self::recombine::Recombine;
 use self::take::Take;
@@ -70,6 +72,15 @@ where
         F: Fn(&P::Individual) -> Result<<P::Individual as Individual>::Fitness, E>,
     {
         self.score(Function::new(scorer))
+    }
+
+    fn hill_climb<M>(self, mutator: M, iterations: usize) -> HillClimb<Self, M>
+    where
+        M: Mutator<P::Individual>,
+        Self: Selector<P, Output = [P::Individual; 1]>,
+        P::Individual: Clone,
+    {
+        HillClimb::new(self, mutator, iterations)
     }
 
     fn evolver<G>(self) -> Select<Self, G>


### PR DESCRIPTION
This adds a new `HillClimb` selector adapter.

The `Mutate` selector adapter added in #7 provides the ability to mutate an individual once. The Hill Climbing algorithm would allow the selected individual to be mutated multiple times while improving the fitness.

This change introduces a new `HillClimb` selector adapter that implements the Hill Climbing algorithm. This uses a fixed number of iterations and only stops at the end of those iterations. This takes a mutator and expects users to manually score the selected individual and mutated individuals.