### PR TITLE
Add `Counter` generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "atomic-traits"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707f750b93bd1b739cf9ddf85f8fe7c97a4a62c60ccf8b6f232514bd9103bedc"
+dependencies = [
+ "cfg-if",
+ "rustc_version",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +176,7 @@ name = "brace-ec"
 version = "0.0.0"
 dependencies = [
  "array-util",
+ "atomic-traits",
  "bytemuck",
  "ghost",
  "itertools 0.14.0",
@@ -1201,6 +1212,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1230,6 +1250,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"

--- a/packages/brace-ec/Cargo.toml
+++ b/packages/brace-ec/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 
 [dependencies]
 array-util = "1.0.2"
+atomic-traits = "0.4.0"
 ghost = "0.1.18"
 itertools = "0.14.0"
 num-traits = "0.2.19"

--- a/packages/brace-ec/src/core/operator/generator/counter.rs
+++ b/packages/brace-ec/src/core/operator/generator/counter.rs
@@ -1,0 +1,62 @@
+use std::convert::Infallible;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use atomic_traits::fetch::Add;
+use num_traits::One;
+
+use super::Generator;
+
+pub struct Counter<T> {
+    atomic: T,
+}
+
+impl<T> Counter<T>
+where
+    T: Add<Type: One>,
+{
+    pub fn new(atomic: T) -> Self {
+        Self { atomic }
+    }
+}
+
+impl Counter<AtomicU64> {
+    pub fn u64() -> Self {
+        Self::new(AtomicU64::new(0))
+    }
+}
+
+impl<T> Generator<T::Type> for Counter<T>
+where
+    T: Add<Type: One>,
+{
+    type Error = Infallible;
+
+    fn generate<Rng>(&self, _: &mut Rng) -> Result<T::Type, Self::Error>
+    where
+        Rng: rand::Rng + ?Sized,
+    {
+        Ok(self.atomic.fetch_add(T::Type::one(), Ordering::Relaxed))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::operator::generator::Generator;
+
+    use super::Counter;
+
+    #[test]
+    fn test_generate() {
+        let mut rng = rand::rng();
+
+        let counter = Counter::u64();
+
+        let a = counter.generate(&mut rng).unwrap();
+        let b = counter.generate(&mut rng).unwrap();
+        let c = counter.generate(&mut rng).unwrap();
+
+        assert_eq!(a, 0);
+        assert_eq!(b, 1);
+        assert_eq!(c, 2);
+    }
+}

--- a/packages/brace-ec/src/core/operator/generator/mod.rs
+++ b/packages/brace-ec/src/core/operator/generator/mod.rs
@@ -1,3 +1,4 @@
+pub mod counter;
 pub mod populate;
 pub mod random;
 
@@ -71,45 +72,5 @@ impl<T, E> Generator<T> for Box<dyn DynGenerator<T, E>> {
         Rng: rand::Rng + ?Sized,
     {
         (**self).dyn_generate(&mut rng)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::cell::Cell;
-    use std::convert::Infallible;
-
-    use super::Generator;
-
-    struct Count(Cell<u8>);
-
-    impl Generator<u8> for Count {
-        type Error = Infallible;
-
-        fn generate<Rng>(&self, _: &mut Rng) -> Result<u8, Self::Error>
-        where
-            Rng: rand::Rng + ?Sized,
-        {
-            let n = self.0.get() + 1;
-
-            self.0.set(n);
-
-            Ok(n)
-        }
-    }
-
-    #[test]
-    fn test_generate() {
-        let mut rng = rand::rng();
-
-        let count = Count(Cell::new(0));
-
-        let a = count.generate(&mut rng).unwrap();
-        let b = count.generate(&mut rng).unwrap();
-        let c = count.generate(&mut rng).unwrap();
-
-        assert_eq!(a, 1);
-        assert_eq!(b, 2);
-        assert_eq!(c, 3);
     }
 }


### PR DESCRIPTION
This adds a new `Counter` generator.

The `generator` module includes a test for the `Generator` trait that defines a custom counter but there is a desire for other tests in other modules to use a similar generator as it produces a consistent output. Rather than duplicating this code it might be beneficial to create a new generator instead. The test implementation uses a `Cell` but using atomics would be better.

This change introduces a new `Counter` generator that uses the `atomic-traits` crate to generically support incrementing atomic number types in the standard library. This isn't particularly useful in evolutionary computation but is useful for testing operators and demonstrating how the crate works. This also removes the tests from the `generator` module as they are now redundant.