### PR TITLE
Add `Search` generator adapter

### DIFF
--- a/packages/brace-ec/src/core/operator/generator/mod.rs
+++ b/packages/brace-ec/src/core/operator/generator/mod.rs
@@ -1,12 +1,14 @@
 pub mod counter;
 pub mod populate;
 pub mod random;
+pub mod search;
 
 use crate::core::individual::Individual;
 use crate::core::population::Population;
 use crate::util::iter::TryFromIterator;
 
 use self::populate::Populate;
+use self::search::Search;
 
 use super::score::Score;
 use super::scorer::function::Function;
@@ -41,6 +43,13 @@ pub trait Generator<T>: Sized {
         T: Individual,
     {
         self.score(Function::new(scorer))
+    }
+
+    fn search(self, iterations: usize) -> Search<Self>
+    where
+        T: Individual,
+    {
+        Search::new(self, iterations)
     }
 
     fn selector<P>(self) -> Generate<Self, P>

--- a/packages/brace-ec/src/core/operator/generator/search.rs
+++ b/packages/brace-ec/src/core/operator/generator/search.rs
@@ -1,0 +1,66 @@
+use itertools::Itertools;
+use thiserror::Error;
+
+use crate::core::individual::Individual;
+
+use super::Generator;
+
+pub struct Search<G> {
+    generator: G,
+    iterations: usize,
+}
+
+impl<G> Search<G> {
+    pub fn new(generator: G, iterations: usize) -> Self {
+        Self {
+            generator,
+            iterations,
+        }
+    }
+}
+
+impl<T, G> Generator<T> for Search<G>
+where
+    T: Individual,
+    G: Generator<T>,
+{
+    type Error = SearchError<G::Error>;
+
+    fn generate<Rng>(&self, rng: &mut Rng) -> Result<T, Self::Error>
+    where
+        Rng: rand::Rng + ?Sized,
+    {
+        (0..self.iterations)
+            .map(|_| self.generator.generate(rng))
+            .process_results(|iter| iter.max_by(|a, b| a.fitness().cmp(b.fitness())))
+            .map_err(SearchError::Generate)?
+            .ok_or(SearchError::Zero)
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum SearchError<G> {
+    #[error("zero iterations")]
+    Zero,
+    #[error(transparent)]
+    Generate(G),
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::operator::generator::counter::Counter;
+    use crate::core::operator::generator::Generator;
+
+    use super::Search;
+
+    #[test]
+    fn test_generate() {
+        let mut rng = rand::rng();
+
+        let a = Search::new(Counter::u64(), 10).generate(&mut rng).unwrap();
+        let b = Counter::u64().search(100).generate(&mut rng).unwrap();
+
+        assert_eq!(a, 9);
+        assert_eq!(b, 99);
+    }
+}


### PR DESCRIPTION
This adds a new `Search` generator adapter that repeatedly calls the inner generator to find a better individual.

The _Random Search_ algorithm is a useful algorithm to include in this project but it unfortunately doesn't fit neatly into the operator API design. In some ways it is similar to the `HillClimb` selector but it is clearly not a selector as it doesn't make use of the population. The best fit is as a generator but even then the name _Random Search_ is a bit of a misnomer as there is no randomness to the number of iterations and it instead relies on the generator itself to be random. However, as can be seen with the introduction of the `Counter` generator in #109, there is no guarantee that a generator is random. The only way to guarantee this would be to hard-code the use of the `Random` generator but that would prevent the `Populate` adapter from being used.

This change introduces a new general-purpose `Search` generator adapter that is effectively a `Repeat` while keeping the best fitness individual. This allows users to build a custom random search by calling the `search` method on an existing generator. For example a chain of `random -> score -> search` or `random -> populate -> score -> search` should produce the desired result. Users need to ensure that `score` is inserted into the operator pipeline but this can be covered by documentation in a future update.