### PR TITLE
Remove associated `Score` from `Scorer` trait

### DIFF
--- a/examples/image/src/scorer.rs
+++ b/examples/image/src/scorer.rs
@@ -18,14 +18,9 @@ impl ImageScorer {
 }
 
 impl Scorer<Scored<Image, u64>> for ImageScorer {
-    type Score = u64;
     type Error = Infallible;
 
-    fn score<Rng>(
-        &self,
-        input: &Scored<Image, u64>,
-        _: &mut Rng,
-    ) -> Result<Self::Score, Self::Error>
+    fn score<Rng>(&self, input: &Scored<Image, u64>, _: &mut Rng) -> Result<u64, Self::Error>
     where
         Rng: rand::Rng + ?Sized,
     {

--- a/packages/brace-ec/src/core/operator/evolver/mod.rs
+++ b/packages/brace-ec/src/core/operator/evolver/mod.rs
@@ -26,10 +26,7 @@ where
 
     fn score<S>(self, scorer: S) -> Score<Self, S>
     where
-        S: Scorer<
-            <G::Population as Population>::Individual,
-            Score = <<G::Population as Population>::Individual as Individual>::Fitness,
-        >,
+        S: Scorer<<G::Population as Population>::Individual>,
     {
         Score::new(self, scorer)
     }

--- a/packages/brace-ec/src/core/operator/generator/mod.rs
+++ b/packages/brace-ec/src/core/operator/generator/mod.rs
@@ -31,7 +31,7 @@ pub trait Generator<T>: Sized {
 
     fn score<S>(self, scorer: S) -> Score<Self, S>
     where
-        S: Scorer<T, Score = T::Fitness>,
+        S: Scorer<T>,
         T: Individual,
     {
         Score::new(self, scorer)

--- a/packages/brace-ec/src/core/operator/mutator/mod.rs
+++ b/packages/brace-ec/src/core/operator/mutator/mod.rs
@@ -26,7 +26,7 @@ where
 
     fn score<S>(self, scorer: S) -> Score<Self, S>
     where
-        S: Scorer<T, Score = T::Fitness>,
+        S: Scorer<T>,
         T: Individual,
     {
         Score::new(self, scorer)

--- a/packages/brace-ec/src/core/operator/recombinator/mod.rs
+++ b/packages/brace-ec/src/core/operator/recombinator/mod.rs
@@ -24,7 +24,7 @@ where
 
     fn score<S>(self, scorer: S) -> Score<Self, S>
     where
-        S: Scorer<P::Individual, Score = <P::Individual as Individual>::Fitness>,
+        S: Scorer<P::Individual>,
     {
         Score::new(self, scorer)
     }

--- a/packages/brace-ec/src/core/operator/score.rs
+++ b/packages/brace-ec/src/core/operator/score.rs
@@ -28,7 +28,7 @@ impl<P, T, S, I> Selector<P> for Score<T, S>
 where
     P: Population<Individual = I> + ?Sized,
     T: Selector<P, Output: TryMap<Item = I>>,
-    S: Scorer<I, Score = I::Fitness>,
+    S: Scorer<I>,
     I: Individual,
 {
     type Output = T::Output;
@@ -53,7 +53,7 @@ where
 impl<T, S, I> Mutator<I> for Score<T, S>
 where
     T: Mutator<I>,
-    S: Scorer<I, Score = I::Fitness>,
+    S: Scorer<I>,
     I: Individual,
 {
     type Error = ScoreError<T::Error, S::Error>;
@@ -80,7 +80,7 @@ impl<P, T, S, I> Recombinator<P> for Score<T, S>
 where
     P: Population<Individual = I>,
     T: Recombinator<P, Output: TryMap<Item = I>>,
-    S: Scorer<I, Score = I::Fitness>,
+    S: Scorer<I>,
     I: Individual,
 {
     type Output = T::Output;
@@ -106,7 +106,7 @@ impl<G, T, S, P, I> Evolver<G> for Score<T, S>
 where
     G: Generation<Population = P>,
     T: Evolver<G>,
-    S: Scorer<I, Score = I::Fitness>,
+    S: Scorer<I>,
     P: Population<Individual = I> + IterableMut<Item = I>,
     I: Individual,
 {
@@ -141,7 +141,7 @@ impl<T, G, S> Generator<T> for Score<G, S>
 where
     T: Individual,
     G: Generator<T>,
-    S: Scorer<T, Score = T::Fitness>,
+    S: Scorer<T>,
 {
     type Error = ScoreError<G::Error, S::Error>;
 

--- a/packages/brace-ec/src/core/operator/scorer/mod.rs
+++ b/packages/brace-ec/src/core/operator/scorer/mod.rs
@@ -6,44 +6,39 @@ pub trait Scorer<T>
 where
     T: Individual,
 {
-    type Score: Ord;
     type Error;
 
-    fn score<Rng>(&self, input: &T, rng: &mut Rng) -> Result<Self::Score, Self::Error>
+    fn score<Rng>(&self, input: &T, rng: &mut Rng) -> Result<T::Fitness, Self::Error>
     where
         Rng: rand::Rng + ?Sized;
 }
 
-pub trait DynScorer<I, S, E = Box<dyn std::error::Error>>
+pub trait DynScorer<I, E = Box<dyn std::error::Error>>
 where
     I: Individual,
-    S: Ord,
 {
-    fn dyn_score(&self, individual: &I, rng: &mut dyn rand::RngCore) -> Result<S, E>;
+    fn dyn_score(&self, individual: &I, rng: &mut dyn rand::RngCore) -> Result<I::Fitness, E>;
 }
 
-impl<I, S, E, T> DynScorer<I, S, E> for T
+impl<I, E, T> DynScorer<I, E> for T
 where
     I: Individual,
-    S: Ord,
-    T: Scorer<I, Score: Into<S>, Error: Into<E>>,
+    T: Scorer<I, Error: Into<E>>,
 {
-    fn dyn_score(&self, individual: &I, rng: &mut dyn rand::RngCore) -> Result<S, E> {
+    fn dyn_score(&self, individual: &I, rng: &mut dyn rand::RngCore) -> Result<I::Fitness, E> {
         self.score(individual, rng)
             .map(Into::into)
             .map_err(Into::into)
     }
 }
 
-impl<I, S, E> Scorer<I> for Box<dyn DynScorer<I, S, E>>
+impl<I, E> Scorer<I> for Box<dyn DynScorer<I, E>>
 where
     I: Individual,
-    S: Ord,
 {
-    type Score = S;
     type Error = E;
 
-    fn score<Rng>(&self, individual: &I, mut rng: &mut Rng) -> Result<Self::Score, Self::Error>
+    fn score<Rng>(&self, individual: &I, mut rng: &mut Rng) -> Result<I::Fitness, Self::Error>
     where
         Rng: rand::Rng + ?Sized,
     {

--- a/packages/brace-ec/src/core/operator/selector/hill_climb.rs
+++ b/packages/brace-ec/src/core/operator/selector/hill_climb.rs
@@ -79,10 +79,9 @@ mod tests {
     struct HillScorer;
 
     impl Scorer<i32> for HillScorer {
-        type Score = i32;
         type Error = Infallible;
 
-        fn score<Rng>(&self, input: &i32, _: &mut Rng) -> Result<Self::Score, Self::Error>
+        fn score<Rng>(&self, input: &i32, _: &mut Rng) -> Result<i32, Self::Error>
         where
             Rng: rand::Rng + ?Sized,
         {

--- a/packages/brace-ec/src/core/operator/selector/mod.rs
+++ b/packages/brace-ec/src/core/operator/selector/mod.rs
@@ -62,7 +62,7 @@ where
 
     fn score<S>(self, scorer: S) -> Score<Self, S>
     where
-        S: Scorer<P::Individual, Score = <P::Individual as Individual>::Fitness>,
+        S: Scorer<P::Individual>,
     {
         Score::new(self, scorer)
     }

--- a/packages/brace-ec/src/core/operator/weighted.rs
+++ b/packages/brace-ec/src/core/operator/weighted.rs
@@ -186,14 +186,13 @@ where
     }
 }
 
-impl<I, O> Weighted<dyn DynScorer<I, O>>
+impl<I> Weighted<dyn DynScorer<I>>
 where
     I: Individual,
-    O: Ord,
 {
     pub fn scorer<S>(scorer: S, weight: u64) -> Self
     where
-        S: Scorer<I, Score = O, Error: Error + 'static> + 'static,
+        S: Scorer<I, Error: Error + 'static> + 'static,
     {
         Self {
             operators: vec![(Box::new(scorer), weight)],
@@ -202,22 +201,20 @@ where
 
     pub fn with_scorer<S>(mut self, scorer: S, weight: u64) -> Self
     where
-        S: Scorer<I, Score: Into<O>, Error: Error + 'static> + 'static,
+        S: Scorer<I, Error: Error + 'static> + 'static,
     {
         self.operators.push((Box::new(scorer), weight));
         self
     }
 }
 
-impl<I, O, E> Scorer<I> for Weighted<dyn DynScorer<I, O, E>>
+impl<I, E> Scorer<I> for Weighted<dyn DynScorer<I, E>>
 where
     I: Individual,
-    O: Ord,
 {
-    type Score = O;
     type Error = E;
 
-    fn score<Rng>(&self, individual: &I, rng: &mut Rng) -> Result<Self::Score, Self::Error>
+    fn score<Rng>(&self, individual: &I, rng: &mut Rng) -> Result<I::Fitness, Self::Error>
     where
         Rng: rand::Rng + ?Sized,
     {

--- a/packages/brace-ec/src/linear/operator/scorer/count.rs
+++ b/packages/brace-ec/src/linear/operator/scorer/count.rs
@@ -33,10 +33,9 @@ where
     T: Individual<Genome: Iterable<Item: PartialEq>, Fitness: Sum<U>>,
     U: Zero + One,
 {
-    type Score = T::Fitness;
     type Error = Infallible;
 
-    fn score<Rng>(&self, individual: &T, _: &mut Rng) -> Result<Self::Score, Self::Error>
+    fn score<Rng>(&self, individual: &T, _: &mut Rng) -> Result<T::Fitness, Self::Error>
     where
         Rng: rand::Rng + ?Sized,
     {

--- a/packages/brace-ec/src/linear/operator/scorer/hiff.rs
+++ b/packages/brace-ec/src/linear/operator/scorer/hiff.rs
@@ -36,10 +36,9 @@ impl<T> Scorer<T> for Hiff<T>
 where
     T: Individual<Genome: AsRef<[bool]>, Fitness: AddAssign<usize>>,
 {
-    type Score = T::Fitness;
     type Error = Infallible;
 
-    fn score<Rng>(&self, individual: &T, _: &mut Rng) -> Result<Self::Score, Self::Error>
+    fn score<Rng>(&self, individual: &T, _: &mut Rng) -> Result<T::Fitness, Self::Error>
     where
         Rng: rand::Rng + ?Sized,
     {


### PR DESCRIPTION
This removes the associated `Score` from the `Scorer` trait.

The `Scorer` trait uses an associated `Score` to specify the output type of the operator. This was useful when the original `Fitness` trait was used to specify the fitness value as it allowed an individual to be scored with an arbitrary type. However, now that all individuals have a fitness since #97, it is possible to simply use the fitness of the individual instead. This would greatly simplify the code.

This change simply removes the associated `Score` from the `Scorer` trait and replaces it with the associated `Fitness` on the individual. This mostly involved removing the associated type bounds but also required a test to be updated as the previous functionality of supporting arbitrary scores is no longer supported. It does not affect or restrict any of the existing operators.

Although this simplifies the code it does remove the ability to score individuals with arbitrary types. This means that it is no longer possible to create composed scorers that combine different scores into a single fitness value. Although it is technically possible to create a fitness that is composed of other fitness values it would not be possible to use an existing scorer to produce a component value as it is tied to the specific fitness of the individual. A wrapper individual could potentially be used but it is not ideal compared to the existing situation.

The current implementation does not make use of composite fitness values and it is not something that is currently planned or on the roadmap. The existing operators would also have no way of selecting which component fitness to use. The associated type could be brought back in the future but until there is a need and specific implementation plan it should be fine to remove.