### PR TITLE
Add `Each` mutator adapter

### DIFF
--- a/packages/brace-ec/src/operator/mutator/each.rs
+++ b/packages/brace-ec/src/operator/mutator/each.rs
@@ -54,9 +54,18 @@ mod tests {
             .rate(0.0)
             .mutate([1, 2, 3], &mut rng)
             .unwrap();
+        let d = Add(1)
+            .rate(1.0)
+            .each()
+            .rate(1.0)
+            .each()
+            .rate(1.0)
+            .mutate([[1, 2], [2, 3], [3, 4]], &mut rng)
+            .unwrap();
 
         assert_eq!(a, [2, 3, 4]);
         assert_eq!(b, [1, 2, 3]);
         assert_eq!(c, [1, 2, 3]);
+        assert_eq!(d, [[2, 3], [3, 4], [4, 5]]);
     }
 }

--- a/packages/brace-ec/src/operator/mutator/each.rs
+++ b/packages/brace-ec/src/operator/mutator/each.rs
@@ -1,0 +1,62 @@
+use std::marker::PhantomData;
+
+use crate::individual::Individual;
+use crate::operator::mutator::Mutator;
+use crate::util::iter::{Iterable, IterableMut};
+
+pub struct Each<M, I> {
+    mutator: M,
+    marker: PhantomData<fn() -> I>,
+}
+
+impl<M, I> Each<M, I> {
+    pub fn new(mutator: M) -> Self {
+        Self {
+            mutator,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<M, I> Mutator<I> for Each<M, I>
+where
+    I: Individual<Genome: IterableMut<Item: Individual + Clone>>,
+    M: Mutator<<I::Genome as Iterable>::Item>,
+{
+    type Error = M::Error;
+
+    fn mutate<Rng>(&self, mut individual: I, rng: &mut Rng) -> Result<I, Self::Error>
+    where
+        Rng: rand::Rng + ?Sized,
+    {
+        for item in individual.genome_mut().iter_mut() {
+            *item = self.mutator.mutate(item.clone(), rng)?;
+        }
+
+        Ok(individual)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::operator::mutator::add::Add;
+    use crate::operator::mutator::Mutator;
+
+    #[test]
+    fn test_mutate() {
+        let mut rng = rand::rng();
+
+        let a = Add(1).rate(1.0).each().mutate([1, 2, 3], &mut rng).unwrap();
+        let b = Add(1).rate(0.0).each().mutate([1, 2, 3], &mut rng).unwrap();
+        let c = Add(1)
+            .rate(1.0)
+            .each()
+            .rate(0.0)
+            .mutate([1, 2, 3], &mut rng)
+            .unwrap();
+
+        assert_eq!(a, [2, 3, 4]);
+        assert_eq!(b, [1, 2, 3]);
+        assert_eq!(c, [1, 2, 3]);
+    }
+}

--- a/packages/brace-ec/src/operator/mutator/mod.rs
+++ b/packages/brace-ec/src/operator/mutator/mod.rs
@@ -1,10 +1,13 @@
 pub mod add;
+pub mod each;
 pub mod invert;
 pub mod noise;
 pub mod rate;
 
 use crate::individual::Individual;
+use crate::util::iter::IterableMut;
 
+use self::each::Each;
 use self::rate::Rate;
 
 use super::evaluate::Evaluate;
@@ -53,6 +56,14 @@ where
 
     fn repeat(self, count: usize) -> Repeat<Self> {
         Repeat::new(self, count)
+    }
+
+    fn each<I>(self) -> Each<Self, I>
+    where
+        I: Individual<Genome: IterableMut<Item = T>>,
+        T: Clone,
+    {
+        Each::new(self)
     }
 
     fn inspect<F>(self, inspector: F) -> Inspect<Self, F>


### PR DESCRIPTION
This adds a new `Each` mutator adapter to mutate sequences.

The existing mutators such as `Add`, `Invert` and `Noise` are designed to work on individuals where the genome is a primitive type such as a number. However, evolutionary computation tends to operate more on individuals where the genome is a sequence such as a bitstring that is composed of a series of bits. As these items may also implement the `Individual` trait it should be possible to adapt the existing mutators to work on all items in a sequence.

This change introduces a new `Each` mutator adapter that applies the mutator to every item in an iterable genome as long as those items themselves are individuals. This allows mutators such as `Invert` and adapters such as `Rate` to support collections via this adapter.