### PR TITLE
Add `Mutator::each_rate` adapter method

### DIFF
--- a/packages/brace-ec/src/operator/mutator/mod.rs
+++ b/packages/brace-ec/src/operator/mutator/mod.rs
@@ -66,6 +66,14 @@ where
         Each::new(self)
     }
 
+    fn each_rate<I>(self, rate: f64) -> Each<Rate<Self>, I>
+    where
+        I: Individual<Genome: IterableMut<Item = T>>,
+        T: Clone,
+    {
+        Each::new(Rate::new(self, rate))
+    }
+
     fn inspect<F>(self, inspector: F) -> Inspect<Self, F>
     where
         F: Fn(&T),


### PR DESCRIPTION
This simply adds a new `each_rate` method to the `Mutator` trait.

This project provides both the `Each` and `Rate` mutator adapters along with the `each` and `rate` adapter methods but it may not be entirely clear which order the methods should be called in. Calling `each` then `rate` would apply the mutator to every item and then that mutator may or may not be applied depending on the rate. Conversely, calling `rate` then `each` may or may not apply the mutator to individual items depending on the rate.

This change introduces a new `each_rate` method to the `Mutator` trait that calls the base mutator at a different rate for each item. This is equivalent to calling `rate` then `each` but in a more natural way. This may seem redundant but it is intended to complement the next feature.