### PR TITLE
Add `EachReciprocalRate` mutator adapter

### DIFF
--- a/packages/brace-ec/src/operator/mutator/each.rs
+++ b/packages/brace-ec/src/operator/mutator/each.rs
@@ -1,5 +1,10 @@
 use std::marker::PhantomData;
 
+use num_traits::ToPrimitive;
+use rand::distr::{Bernoulli, Distribution};
+use thiserror::Error;
+
+use crate::chromosome::Chromosome;
 use crate::individual::Individual;
 use crate::operator::mutator::Mutator;
 use crate::util::iter::{Iterable, IterableMut};
@@ -37,13 +42,78 @@ where
     }
 }
 
+pub struct EachReciprocalRate<M, I> {
+    mutator: M,
+    marker: PhantomData<fn() -> I>,
+}
+
+impl<M, I> EachReciprocalRate<M, I> {
+    pub fn new(mutator: M) -> Self {
+        Self {
+            mutator,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<I, M, G> Mutator<I> for EachReciprocalRate<M, I>
+where
+    I: Individual<Genome: Chromosome<Gene = G>>,
+    M: Mutator<G>,
+    G: Individual + Clone,
+{
+    type Error = EachReciprocalRateError<M::Error>;
+
+    fn mutate<Rng>(&self, mut individual: I, rng: &mut Rng) -> Result<I, Self::Error>
+    where
+        Rng: rand::Rng + ?Sized,
+    {
+        let len = individual
+            .genome()
+            .len()
+            .to_u32()
+            .ok_or(EachReciprocalRateError::TooLarge)?;
+
+        if len == 0 {
+            return Ok(individual);
+        }
+
+        let distr = Bernoulli::from_ratio(1, len).expect("len greater than or equal to 1");
+
+        for index in 0..individual.genome().len() {
+            if distr.sample(rng) {
+                let gene = individual
+                    .genome_mut()
+                    .gene_mut(index)
+                    .expect("index less than length");
+
+                *gene = self
+                    .mutator
+                    .mutate(gene.clone(), rng)
+                    .map_err(EachReciprocalRateError::Mutate)?;
+            }
+        }
+
+        Ok(individual)
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum EachReciprocalRateError<M> {
+    #[error("chromosome length is too large")]
+    TooLarge,
+    #[error(transparent)]
+    Mutate(M),
+}
+
 #[cfg(test)]
 mod tests {
+    use crate::individual::Individual;
     use crate::operator::mutator::add::Add;
     use crate::operator::mutator::Mutator;
 
     #[test]
-    fn test_mutate() {
+    fn test_mutate_each() {
         let mut rng = rand::rng();
 
         let a = Add(1).rate(1.0).each().mutate([1, 2, 3], &mut rng).unwrap();
@@ -67,5 +137,16 @@ mod tests {
         assert_eq!(b, [1, 2, 3]);
         assert_eq!(c, [1, 2, 3]);
         assert_eq!(d, [[2, 3], [3, 4], [4, 5]]);
+    }
+
+    #[test]
+    fn test_mutate_each_reciprocal_rate() {
+        let a = [1, 2].mutated(Add(1).each_reciprocal_rate()).unwrap();
+        let b = [1, 2]
+            .mutated(Add(1).each_reciprocal_rate().rate(0.0))
+            .unwrap();
+
+        assert!(a == [1, 2] || a == [2, 2] || a == [1, 3] || a == [2, 3]);
+        assert_eq!(b, [1, 2]);
     }
 }

--- a/packages/brace-ec/src/operator/mutator/mod.rs
+++ b/packages/brace-ec/src/operator/mutator/mod.rs
@@ -4,10 +4,11 @@ pub mod invert;
 pub mod noise;
 pub mod rate;
 
+use crate::chromosome::Chromosome;
 use crate::individual::Individual;
 use crate::util::iter::IterableMut;
 
-use self::each::Each;
+use self::each::{Each, EachReciprocalRate};
 use self::rate::Rate;
 
 use super::evaluate::Evaluate;
@@ -72,6 +73,14 @@ where
         T: Clone,
     {
         Each::new(Rate::new(self, rate))
+    }
+
+    fn each_reciprocal_rate<I>(self) -> EachReciprocalRate<Self, I>
+    where
+        I: Individual<Genome: Chromosome<Gene = T>>,
+        T: Clone,
+    {
+        EachReciprocalRate::new(self)
     }
 
     fn inspect<F>(self, inspector: F) -> Inspect<Self, F>


### PR DESCRIPTION
This adds a new `EachReciprocalRate` mutator adapter that mutates at a rate depending on the number of items.

The `Rate` mutator adapter is useful but it requires users to input a specific rate. In Evolutionary Computation it is often desired to mutate at a rate that is the reciprocal of the length, i.e. `1 / length`. However, in order to accomplish this, users would need to calculate this themselves and ensure it stays up to date if the length changes. This is not too difficult to do but it would be easier to provide a new mutator adapter to handle the calculation automatically.

This change introduces a new `EachReciprocalRate` mutator adapter and `each_reciprocal_rate` adapter method that applies the base mutator to each item in a genome at the rate of `1 / length`. This is included in the `each` module instead of the `rate` module despite the overlap as it makes more logical sense. Unfortunately, it was not possible to create a standalone `ReciprocalRate` mutator that could be used in combination with `Each`.

The implementation of `EachReciprocalRate` differs from the implementation of `Each` as it uses the `Chromosome` trait instead of `IterableMut`. For `Each` it made sense to iterate as every item would have a mutator applied. However, as the rate is built in it is unlikely that a mutator would be applied to each individual and so indexed access is the better option. The `Chromosome` trait also provides a length and that would avoid counting the items to calculate the value for the denominator.

This makes use of the `Bernoulli` distribution and the `from_ratio` constructor which takes `u32` values. This is presumably because a `u64` is likely to have precision loss when converted to an `f64` to calculate the rate. Therefore this operator returns an error when the length of the chromosome exceeds the size of a `u32`. This was deemed a better option than a potentially incorrect rate although the length is unlikely to ever approach the maximum.