### PR TITLE
Replace `get_range_to` utility with `bound_range`

### DIFF
--- a/packages/brace-ec/src/chromosome/crossover.rs
+++ b/packages/brace-ec/src/chromosome/crossover.rs
@@ -1,7 +1,7 @@
 use std::mem;
 use std::ops::RangeBounds;
 
-use crate::util::range::{get_range_to, get_slice_range_mut};
+use crate::util::range::{bound_range, get_range, get_slice_range_mut};
 
 use super::Chromosome;
 
@@ -12,7 +12,7 @@ pub trait Crossover: Chromosome {
     where
         R: RangeBounds<usize>,
     {
-        for index in get_range_to(range, self.len()) {
+        for index in bound_range(get_range(range), 0..self.len()) {
             self.crossover_gene(other, index);
         }
     }

--- a/packages/brace-ec/src/util/range.rs
+++ b/packages/brace-ec/src/util/range.rs
@@ -1,3 +1,4 @@
+use std::cmp::{max, min};
 use std::ops::{Add, Bound, Range, RangeBounds};
 
 use num_traits::{Bounded, One};
@@ -22,27 +23,24 @@ where
     start..end
 }
 
-pub fn get_range_to<R>(range: R, max: usize) -> Range<usize>
+pub fn bound_range<T, B>(range: Range<T>, bounds: B) -> Range<T>
 where
-    R: RangeBounds<usize>,
+    B: RangeBounds<T>,
+    T: Ord + Clone + One + Add<Output = T>,
 {
-    match range.start_bound() {
-        Bound::Included(&start) => match range.end_bound() {
-            Bound::Included(&end) => start..((end + 1).min(max)),
-            Bound::Excluded(&end) => start..((end).min(max)),
-            Bound::Unbounded => start..max,
-        },
-        Bound::Excluded(&start) => match range.end_bound() {
-            Bound::Included(&end) => (start + 1)..((end + 1).min(max)),
-            Bound::Excluded(&end) => (start + 1)..(end.min(max)),
-            Bound::Unbounded => (start + 1)..max,
-        },
-        Bound::Unbounded => match range.end_bound() {
-            Bound::Included(&end) => 0..(end.min(max)),
-            Bound::Excluded(&end) => 0..(end.min(max)),
-            Bound::Unbounded => 0..max,
-        },
-    }
+    let start = match bounds.start_bound() {
+        Bound::Included(start) => max(range.start, start.clone()),
+        Bound::Excluded(start) => max(range.start, start.clone() + T::one()),
+        Bound::Unbounded => range.start,
+    };
+
+    let end = match bounds.end_bound() {
+        Bound::Included(end) => min(range.end, end.clone() + T::one()),
+        Bound::Excluded(end) => min(range.end, end.clone()),
+        Bound::Unbounded => range.end,
+    };
+
+    start..end
 }
 
 pub fn get_slice_range_mut<'a, T, R>(input: &'a mut [T], range: &R) -> &'a mut [T]
@@ -65,5 +63,35 @@ where
             Bound::Excluded(&end) => &mut input[..end],
             Bound::Unbounded => input,
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{bound_range, get_range};
+
+    #[test]
+    fn test_get_range() {
+        assert_eq!(get_range(..), i32::MIN..i32::MAX);
+        assert_eq!(get_range(5..), 5..i32::MAX);
+        assert_eq!(get_range(..10), i32::MIN..10);
+        assert_eq!(get_range(..=20), i32::MIN..21);
+        assert_eq!(get_range(2..8), 2..8);
+        assert_eq!(get_range(4..=25), 4..26);
+    }
+
+    #[test]
+    fn test_bound_range() {
+        assert_eq!(bound_range(1..10, ..), 1..10);
+        assert_eq!(bound_range(1..10, 0..), 1..10);
+        assert_eq!(bound_range(1..10, 2..), 2..10);
+        assert_eq!(bound_range(1..10, ..6), 1..6);
+        assert_eq!(bound_range(1..10, ..20), 1..10);
+        assert_eq!(bound_range(1..10, ..=6), 1..7);
+        assert_eq!(bound_range(1..10, ..=20), 1..10);
+        assert_eq!(bound_range(1..10, 0..20), 1..10);
+        assert_eq!(bound_range(1..10, 2..6), 2..6);
+        assert_eq!(bound_range(1..10, 0..=20), 1..10);
+        assert_eq!(bound_range(1..10, 2..=6), 2..7);
     }
 }


### PR DESCRIPTION
This replaces the `get_range_to` utility function with a new `bound_range` function.

The `get_range_to` utility function was added to support the default implementation of `crossover_segment` in the `Crossover` trait. The idea was to support a generic range using the `RangeBounds` trait with the ability to set a maximum value to ensure that it didn't exceed the length of the chromosome. However, the implementation of the `get_range_to` function mistakenly used the wrong end bound in one of the match branches. This went unnoticed partly due to the lack of tests but also because all of the implementations of `Crossover` override this method.

This change removes the `get_range_to` utility function and replaces it with a new `bound_range` function that is more general and supports restricting both the start and end bounds. This is inspired by the newer `get_range` function and is meant to be used in conjunction with it to perform the functionality of `get_range_to`. This includes tests for both the `get_range` and `bound_range` functions to ensure that they are correct.