### PR TITLE
Add `ParSearch` generator adapter

### DIFF
--- a/packages/brace-ec/src/operator/generator/mod.rs
+++ b/packages/brace-ec/src/operator/generator/mod.rs
@@ -8,7 +8,7 @@ use crate::population::Population;
 use crate::util::iter::TryFromIterator;
 
 use self::populate::Populate;
-use self::search::Search;
+use self::search::{ParSearch, Search};
 
 use super::evaluate::Evaluate;
 use super::evaluator::function::Function;
@@ -50,6 +50,15 @@ pub trait Generator<T>: Sized {
         T: Individual,
     {
         Search::new(self, iterations)
+    }
+
+    fn par_search(self, iterations: usize) -> ParSearch<Self>
+    where
+        T: Individual + Send,
+        Self: Sync,
+        Self::Error: Send,
+    {
+        ParSearch::new(self, iterations)
     }
 
     fn selector<P>(self) -> Generate<Self, P>


### PR DESCRIPTION
This adds a new `ParSearch` generator adapter.

The `Search` generator adapter was introduced in #110 to support the implementation of the _Random Search_ algorithm by picking the best generated individual over a given number of iterations. This used a serial implementation but in order to speed up generation it may be beneficial to use a parallel implementation instead.

This change introduces a new `ParSearch` generator adapter that is simply a parallel version of the `Search` generator adapter. This includes a `par_search` adapter method on the `Generator` trait.