### PR TITLE
Add `HillClimb` selector evaluate methods

### DIFF
--- a/packages/brace-ec/src/operator/selector/hill_climb.rs
+++ b/packages/brace-ec/src/operator/selector/hill_climb.rs
@@ -41,6 +41,20 @@ impl<S, M> HillClimb<S, M> {
             iterations: self.iterations,
         }
     }
+
+    pub fn evaluate_mutations<T, P>(self, evaluator: T) -> HillClimb<S, Evaluate<M, T>>
+    where
+        P: Population<Individual: Clone> + ?Sized,
+        T: Evaluator<P::Individual>,
+        S: Selector<P, Output = [P::Individual; 1]>,
+        M: Mutator<P::Individual>,
+    {
+        HillClimb {
+            selector: self.selector,
+            mutator: self.mutator.evaluate(evaluator),
+            iterations: self.iterations,
+        }
+    }
 }
 
 impl<P, S, M> Selector<P> for HillClimb<S, M>
@@ -135,10 +149,16 @@ mod tests {
             .evaluate_iterations(HillEvaluator)
             .select(&[1, 2, 3, 4, 5], &mut rng)
             .unwrap();
+        let e = Best
+            .hill_climb(Add(1), 10)
+            .evaluate_mutations(HillEvaluator)
+            .select(&[1, 2, 3, 4, 5], &mut rng)
+            .unwrap();
 
         assert_eq!(a, [15]);
         assert_eq!(b, [15]);
         assert_eq!(c, [9]);
         assert_eq!(d, [9]);
+        assert_eq!(e, [9]);
     }
 }

--- a/packages/brace-ec/src/operator/selector/hill_climb.rs
+++ b/packages/brace-ec/src/operator/selector/hill_climb.rs
@@ -25,7 +25,10 @@ impl<S, M> HillClimb<S, M> {
 }
 
 impl<S, M> HillClimb<S, M> {
-    pub fn evaluate<T, P>(self, evaluator: T) -> HillClimb<Evaluate<S, T>, Evaluate<M, T>>
+    pub fn evaluate_iterations<T, P>(
+        self,
+        evaluator: T,
+    ) -> HillClimb<Evaluate<S, T>, Evaluate<M, T>>
     where
         P: Population<Individual: Clone> + ?Sized,
         T: Evaluator<P::Individual> + Clone,
@@ -129,7 +132,7 @@ mod tests {
             .unwrap();
         let d = Best
             .hill_climb(Add(1), 10)
-            .evaluate(HillEvaluator)
+            .evaluate_iterations(HillEvaluator)
             .select(&[1, 2, 3, 4, 5], &mut rng)
             .unwrap();
 


### PR DESCRIPTION
This adds a new `evaluate` method to the `HillClimb` selector.

The `HillClimb` selector is a composition of a selector and a mutator that simply returns the best individual within a set of iterations. The implementation relies on the mutated individuals being correctly evaluated so that the best fitness individual can be chosen. This requires users to call `evaluate` on the mutator passed in. It may also require users to call `evaluate` on the selected individual but this depends on whether the selected individual has previously been evaluated. Calling `evaluate` on the `HillClimb` type itself is almost never what you want as it would result in the selected individual being evaluated which should already happen within the selector.

This change introduces new `evaluate_iterations` and `evaluate_mutations` methods on the `HillClimb` selector that transform the inner operators. The former adapts both the selector and mutator with the given evaluator, requiring the `Clone` bound, whereas the latter adapts just the inner mutator with the given evaluator.

These methods are an alternative to chaining on the selector and/or mutator directly but otherwise provide no new functionality. The original plan was to override the `evaluate` method but it is possible that users will want to hill climb with a separate evaluator and then evaluate again. The `evaluate_iterations` method ensures that both the selected and mutated individuals are evaluated consistently whereas the `evaluate_mutations` method assumes that the selected individual has already been evaluated.