### PR TITLE
Add `Send + Sync` to dyn-compatible operator errors

### DIFF
--- a/packages/brace-ec/src/operator/evaluator/mod.rs
+++ b/packages/brace-ec/src/operator/evaluator/mod.rs
@@ -2,6 +2,8 @@ pub mod count;
 pub mod function;
 pub mod hiff;
 
+use std::error::Error;
+
 use crate::individual::Individual;
 
 pub trait Evaluator<T>
@@ -15,7 +17,7 @@ where
         Rng: rand::Rng + ?Sized;
 }
 
-pub trait DynEvaluator<I, E = Box<dyn std::error::Error>>
+pub trait DynEvaluator<I, E = Box<dyn Error + Send + Sync>>
 where
     I: Individual,
 {

--- a/packages/brace-ec/src/operator/evolver/mod.rs
+++ b/packages/brace-ec/src/operator/evolver/mod.rs
@@ -1,6 +1,8 @@
 pub mod limit;
 pub mod select;
 
+use std::error::Error;
+
 use crate::generation::Generation;
 use crate::individual::Individual;
 use crate::population::Population;
@@ -65,7 +67,7 @@ where
     }
 }
 
-pub trait DynEvolver<G, E = Box<dyn std::error::Error>>
+pub trait DynEvolver<G, E = Box<dyn Error + Send + Sync>>
 where
     G: Generation,
 {

--- a/packages/brace-ec/src/operator/generator/mod.rs
+++ b/packages/brace-ec/src/operator/generator/mod.rs
@@ -3,6 +3,8 @@ pub mod populate;
 pub mod random;
 pub mod search;
 
+use std::error::Error;
+
 use crate::individual::Individual;
 use crate::population::Population;
 use crate::util::iter::TryFromIterator;
@@ -69,7 +71,7 @@ pub trait Generator<T>: Sized {
     }
 }
 
-pub trait DynGenerator<T, E = Box<dyn std::error::Error>> {
+pub trait DynGenerator<T, E = Box<dyn Error + Send + Sync>> {
     fn dyn_generate(&self, rng: &mut dyn rand::RngCore) -> Result<T, E>;
 }
 

--- a/packages/brace-ec/src/operator/mutator/mod.rs
+++ b/packages/brace-ec/src/operator/mutator/mod.rs
@@ -4,6 +4,8 @@ pub mod invert;
 pub mod noise;
 pub mod rate;
 
+use std::error::Error;
+
 use crate::chromosome::Chromosome;
 use crate::individual::Individual;
 use crate::util::iter::IterableMut;
@@ -91,7 +93,7 @@ where
     }
 }
 
-pub trait DynMutator<I, E = Box<dyn std::error::Error>>
+pub trait DynMutator<I, E = Box<dyn Error + Send + Sync>>
 where
     I: Individual,
 {

--- a/packages/brace-ec/src/operator/recombinator/mod.rs
+++ b/packages/brace-ec/src/operator/recombinator/mod.rs
@@ -3,6 +3,8 @@ pub mod point;
 pub mod sum;
 pub mod uniform;
 
+use std::error::Error;
+
 use crate::individual::Individual;
 use crate::population::Population;
 
@@ -57,8 +59,11 @@ where
     }
 }
 
-pub trait DynRecombinator<P, O = Vec<<P as Population>::Individual>, E = Box<dyn std::error::Error>>
-where
+pub trait DynRecombinator<
+    P,
+    O = Vec<<P as Population>::Individual>,
+    E = Box<dyn Error + Send + Sync>,
+> where
     P: Population,
     O: Population<Individual = P::Individual>,
 {

--- a/packages/brace-ec/src/operator/selector/mod.rs
+++ b/packages/brace-ec/src/operator/selector/mod.rs
@@ -13,6 +13,8 @@ pub mod tournament;
 pub mod windows;
 pub mod worst;
 
+use std::error::Error;
+
 use crate::generation::Generation;
 use crate::individual::Individual;
 use crate::population::Population;
@@ -167,7 +169,7 @@ where
     }
 }
 
-pub trait DynSelector<P, O = Vec<<P as Population>::Individual>, E = Box<dyn std::error::Error>>
+pub trait DynSelector<P, O = Vec<<P as Population>::Individual>, E = Box<dyn Error + Send + Sync>>
 where
     P: Population + ?Sized,
     O: Population<Individual = P::Individual>,

--- a/packages/brace-ec/src/operator/weighted.rs
+++ b/packages/brace-ec/src/operator/weighted.rs
@@ -27,7 +27,7 @@ where
 {
     pub fn selector<S>(selector: S, weight: u64) -> Self
     where
-        S: Selector<P, Output = O, Error: Error + 'static> + 'static,
+        S: Selector<P, Output = O, Error: Error + Send + Sync + 'static> + 'static,
     {
         Self {
             operators: vec![(Box::new(selector), weight)],
@@ -36,7 +36,7 @@ where
 
     pub fn with_selector<S>(mut self, selector: S, weight: u64) -> Self
     where
-        S: Selector<P, Output: Into<O>, Error: Error + 'static> + 'static,
+        S: Selector<P, Output: Into<O>, Error: Error + Send + Sync + 'static> + 'static,
     {
         self.operators.push((Box::new(selector), weight));
         self
@@ -69,7 +69,7 @@ where
 {
     pub fn mutator<M>(mutator: M, weight: u64) -> Self
     where
-        M: Mutator<I, Error: Error + 'static> + 'static,
+        M: Mutator<I, Error: Error + Send + Sync + 'static> + 'static,
     {
         Self {
             operators: vec![(Box::new(mutator), weight)],
@@ -78,7 +78,7 @@ where
 
     pub fn with_mutator<M>(mut self, mutator: M, weight: u64) -> Self
     where
-        M: Mutator<I, Error: Error + 'static> + 'static,
+        M: Mutator<I, Error: Error + Send + Sync + 'static> + 'static,
     {
         self.operators.push((Box::new(mutator), weight));
         self
@@ -110,7 +110,7 @@ where
 {
     pub fn recombinator<R>(recombinator: R, weight: u64) -> Self
     where
-        R: Recombinator<P, Output = O, Error: Error + 'static> + 'static,
+        R: Recombinator<P, Output = O, Error: Error + Send + Sync + 'static> + 'static,
     {
         Self {
             operators: vec![(Box::new(recombinator), weight)],
@@ -119,7 +119,7 @@ where
 
     pub fn with_recombinator<R>(mut self, recombinator: R, weight: u64) -> Self
     where
-        R: Recombinator<P, Output: Into<O>, Error: Error + 'static> + 'static,
+        R: Recombinator<P, Output: Into<O>, Error: Error + Send + Sync + 'static> + 'static,
     {
         self.operators.push((Box::new(recombinator), weight));
         self
@@ -152,7 +152,7 @@ where
 {
     pub fn evolver<E>(evolver: E, weight: u64) -> Self
     where
-        E: Evolver<G, Error: Error + 'static> + 'static,
+        E: Evolver<G, Error: Error + Send + Sync + 'static> + 'static,
     {
         Self {
             operators: vec![(Box::new(evolver), weight)],
@@ -161,7 +161,7 @@ where
 
     pub fn with_evolver<M>(mut self, evolver: M, weight: u64) -> Self
     where
-        M: Evolver<G, Error: Error + 'static> + 'static,
+        M: Evolver<G, Error: Error + Send + Sync + 'static> + 'static,
     {
         self.operators.push((Box::new(evolver), weight));
         self
@@ -192,7 +192,7 @@ where
 {
     pub fn evaluator<S>(evaluator: S, weight: u64) -> Self
     where
-        S: Evaluator<I, Error: Error + 'static> + 'static,
+        S: Evaluator<I, Error: Error + Send + Sync + 'static> + 'static,
     {
         Self {
             operators: vec![(Box::new(evaluator), weight)],
@@ -201,7 +201,7 @@ where
 
     pub fn with_evaluator<S>(mut self, evaluator: S, weight: u64) -> Self
     where
-        S: Evaluator<I, Error: Error + 'static> + 'static,
+        S: Evaluator<I, Error: Error + Send + Sync + 'static> + 'static,
     {
         self.operators.push((Box::new(evaluator), weight));
         self
@@ -229,7 +229,7 @@ where
 impl<T> Weighted<dyn DynGenerator<T>> {
     pub fn generator<G>(generator: G, weight: u64) -> Self
     where
-        G: Generator<T, Error: Error + 'static> + 'static,
+        G: Generator<T, Error: Error + Send + Sync + 'static> + 'static,
     {
         Self {
             operators: vec![(Box::new(generator), weight)],
@@ -238,7 +238,7 @@ impl<T> Weighted<dyn DynGenerator<T>> {
 
     pub fn with_generator<G>(mut self, generator: G, weight: u64) -> Self
     where
-        G: Generator<T, Error: Error + 'static> + 'static,
+        G: Generator<T, Error: Error + Send + Sync + 'static> + 'static,
     {
         self.operators.push((Box::new(generator), weight));
         self


### PR DESCRIPTION
This adds `Send` and `Sync` bounds to dyn-compatible operator errors.

The various operator traits provide dyn-compatible variants where the associated error defaults to a boxed error. Although the operators themselves might not be `Send` and `Sync` the errors are likely to be. Therefore the default error should be updated to add the `Send` and `Sync` bounds.

This change updates the various dyn-compatible operator traits to add the `Send` and `Sync` bounds to the default error type and updates the `Weighted` operator to require them as it uses the defaults.