### PR TITLE
Rename `evaluate` parameter `input` to `individual`

### DIFF
--- a/examples/image/src/evaluator.rs
+++ b/examples/image/src/evaluator.rs
@@ -20,11 +20,15 @@ impl ImageEvaluator {
 impl Evaluator<Evaluated<Image, u64>> for ImageEvaluator {
     type Error = Infallible;
 
-    fn evaluate<Rng>(&self, input: &Evaluated<Image, u64>, _: &mut Rng) -> Result<u64, Self::Error>
+    fn evaluate<Rng>(
+        &self,
+        individual: &Evaluated<Image, u64>,
+        _: &mut Rng,
+    ) -> Result<u64, Self::Error>
     where
         Rng: rand::Rng + ?Sized,
     {
-        let fitness = input
+        let fitness = individual
             .genome()
             .iter()
             .zip(self.image.genome().iter())

--- a/packages/brace-ec/src/operator/evaluator/mod.rs
+++ b/packages/brace-ec/src/operator/evaluator/mod.rs
@@ -12,7 +12,7 @@ where
 {
     type Error;
 
-    fn evaluate<Rng>(&self, input: &T, rng: &mut Rng) -> Result<T::Fitness, Self::Error>
+    fn evaluate<Rng>(&self, individual: &T, rng: &mut Rng) -> Result<T::Fitness, Self::Error>
     where
         Rng: rand::Rng + ?Sized;
 }

--- a/packages/brace-ec/src/operator/selector/hill_climb.rs
+++ b/packages/brace-ec/src/operator/selector/hill_climb.rs
@@ -117,13 +117,13 @@ mod tests {
     impl Evaluator<i32> for HillEvaluator {
         type Error = Infallible;
 
-        fn evaluate<Rng>(&self, input: &i32, _: &mut Rng) -> Result<i32, Self::Error>
+        fn evaluate<Rng>(&self, individual: &i32, _: &mut Rng) -> Result<i32, Self::Error>
         where
             Rng: rand::Rng + ?Sized,
         {
-            match input {
+            match individual {
                 10 => Ok(0),
-                _ => Ok(*input),
+                _ => Ok(*individual),
             }
         }
     }


### PR DESCRIPTION
This simply renames the `input` parameter in `Evaluator::evaluate` to `individual`.

The `Evaluator` operator trait originally started out as `Scorer` and was designed to score any type. This has since been updated and now requires an `Individual` as the input. However, the parameter name has not been updated.

This change updates the `input` parameter name in the `evalauate` method of `Evaluator` to `individual` so that Rust Analyzer correctly fills in the correct name when implementing missing members. This also updates the usages of the trait to no longer to refer to an input.