### PR TITLE
Add `IntoParallelOperator` trait

### DIFF
--- a/packages/brace-ec/src/operator/mod.rs
+++ b/packages/brace-ec/src/operator/mod.rs
@@ -10,3 +10,18 @@ pub mod repeat;
 pub mod selector;
 pub mod then;
 pub mod weighted;
+
+use self::either::Either;
+
+pub trait IntoParallelOperator: Sized {
+    type Op;
+
+    fn parallel(self) -> Self::Op;
+
+    fn parallel_if(self, parallel: bool) -> Either<Self, Self::Op> {
+        match parallel {
+            false => Either::A(self),
+            true => Either::B(self.parallel()),
+        }
+    }
+}


### PR DESCRIPTION
This adds a new `IntoParallelOperator` helper trait to convert an operator to a parallel operator.

Some of the operators in the project such as `Search`, `Fill`, `Windows` and `ArrayWindows` each have a corresponding parallel implementation. There should be a simple way to convert the non-parallel version to the parallel version.

This change introduces a new `IntoParallelOperator` trait that is similar to the `IntoParallelIterator` trait from `rayon`. This uses an associated type to specify the equivalent parallel operator and a method to perform the conversion. This method is called `parallel` instead of `into_par_operator` to fit in with the operator pipeline method naming conventions.

This also includes a `parallel_if` method with a default implementation that uses the `Either` operator from #123 to support either the parallel or non-parallel versions depending on the condition.