### PR TITLE
Add `RepeatN` operator adapter

### DIFF
--- a/packages/brace-ec/src/operator/evolver/mod.rs
+++ b/packages/brace-ec/src/operator/evolver/mod.rs
@@ -13,7 +13,7 @@ use super::evaluate::Evaluate;
 use super::evaluator::function::Function;
 use super::evaluator::Evaluator;
 use super::inspect::Inspect;
-use super::repeat::Repeat;
+use super::repeat::{Repeat, RepeatN};
 use super::then::Then;
 
 pub trait Evolver<G>: Sized
@@ -53,6 +53,10 @@ where
 
     fn repeat(self, count: usize) -> Repeat<Self> {
         Repeat::new(self, count)
+    }
+
+    fn repeat_n<const N: usize>(self) -> RepeatN<N, Self> {
+        RepeatN::new(self)
     }
 
     fn limit(self, generation: G::Id) -> Limit<G, Self> {

--- a/packages/brace-ec/src/operator/mutator/mod.rs
+++ b/packages/brace-ec/src/operator/mutator/mod.rs
@@ -17,7 +17,7 @@ use super::evaluate::Evaluate;
 use super::evaluator::function::Function;
 use super::evaluator::Evaluator;
 use super::inspect::Inspect;
-use super::repeat::Repeat;
+use super::repeat::{Repeat, RepeatN};
 use super::then::Then;
 
 pub trait Mutator<T>: Sized
@@ -59,6 +59,10 @@ where
 
     fn repeat(self, count: usize) -> Repeat<Self> {
         Repeat::new(self, count)
+    }
+
+    fn repeat_n<const N: usize>(self) -> RepeatN<N, Self> {
+        RepeatN::new(self)
     }
 
     fn each<I>(self) -> Each<Self, I>

--- a/packages/brace-ec/src/operator/recombinator/mod.rs
+++ b/packages/brace-ec/src/operator/recombinator/mod.rs
@@ -12,7 +12,7 @@ use super::evaluate::Evaluate;
 use super::evaluator::function::Function;
 use super::evaluator::Evaluator;
 use super::inspect::Inspect;
-use super::repeat::Repeat;
+use super::repeat::{Repeat, RepeatN};
 use super::then::Then;
 
 pub trait Recombinator<P>: Sized
@@ -49,6 +49,10 @@ where
 
     fn repeat(self, count: usize) -> Repeat<Self> {
         Repeat::new(self, count)
+    }
+
+    fn repeat_n<const N: usize>(self) -> RepeatN<N, Self> {
+        RepeatN::new(self)
     }
 
     fn inspect<F>(self, inspector: F) -> Inspect<Self, F>

--- a/packages/brace-ec/src/operator/selector/mod.rs
+++ b/packages/brace-ec/src/operator/selector/mod.rs
@@ -34,7 +34,7 @@ use super::evolver::select::Select;
 use super::inspect::Inspect;
 use super::mutator::Mutator;
 use super::recombinator::Recombinator;
-use super::repeat::Repeat;
+use super::repeat::{Repeat, RepeatN};
 use super::then::Then;
 
 pub trait Selector<P>: Sized
@@ -158,6 +158,10 @@ where
         Self: Sized,
     {
         Repeat::new(self, count)
+    }
+
+    fn repeat_n<const N: usize>(self) -> RepeatN<N, Self> {
+        RepeatN::new(self)
     }
 
     fn inspect<F>(self, inspector: F) -> Inspect<Self, F>


### PR DESCRIPTION
This adds a new `RepeatN` operator adapter.

The `Repeat` operator adapter uses a parameter to select how many times the interior operator will be repeated. This works well for the `Mutator`, `Recombinator` and `Evolver` operators but the `Selector` implementation returns a `Vec` because it cannot know how many individuals will be produced at compile time. This requires users to then use the `Take` selector adapter to specify a const generic number in order to use the recombinators. The project should provide an alternative repeat operator that uses a constant generic instead.

This change introduces the `RepeatN` operator adapter that works much the same way as the `Repeat` operator adapter with the exception that it uses a const generic number instead of a parameter. The implementation of the `Selector` operator requires that the base selector return a single individual rather than multiple. This then allows it to return `N` individuals based on the const generic.