### PR TITLE
Implement operators for `Box` with `Send + Sync`

### DIFF
--- a/packages/brace-ec/src/operator/evaluator/mod.rs
+++ b/packages/brace-ec/src/operator/evaluator/mod.rs
@@ -49,3 +49,17 @@ where
         (**self).dyn_evaluate(individual, &mut rng)
     }
 }
+
+impl<I, E> Evaluator<I> for Box<dyn DynEvaluator<I, E> + Send + Sync>
+where
+    I: Individual,
+{
+    type Error = E;
+
+    fn evaluate<Rng>(&self, individual: &I, mut rng: &mut Rng) -> Result<I::Fitness, Self::Error>
+    where
+        Rng: rand::Rng + ?Sized,
+    {
+        (**self).dyn_evaluate(individual, &mut rng)
+    }
+}

--- a/packages/brace-ec/src/operator/evolver/mod.rs
+++ b/packages/brace-ec/src/operator/evolver/mod.rs
@@ -101,3 +101,17 @@ where
         (**self).dyn_evolve(individual, &mut rng)
     }
 }
+
+impl<G, E> Evolver<G> for Box<dyn DynEvolver<G, E> + Send + Sync>
+where
+    G: Generation,
+{
+    type Error = E;
+
+    fn evolve<Rng>(&self, individual: G, mut rng: &mut Rng) -> Result<G, Self::Error>
+    where
+        Rng: rand::Rng + ?Sized,
+    {
+        (**self).dyn_evolve(individual, &mut rng)
+    }
+}

--- a/packages/brace-ec/src/operator/generator/mod.rs
+++ b/packages/brace-ec/src/operator/generator/mod.rs
@@ -94,3 +94,14 @@ impl<T, E> Generator<T> for Box<dyn DynGenerator<T, E>> {
         (**self).dyn_generate(&mut rng)
     }
 }
+
+impl<T, E> Generator<T> for Box<dyn DynGenerator<T, E> + Send + Sync> {
+    type Error = E;
+
+    fn generate<Rng>(&self, mut rng: &mut Rng) -> Result<T, Self::Error>
+    where
+        Rng: rand::Rng + ?Sized,
+    {
+        (**self).dyn_generate(&mut rng)
+    }
+}

--- a/packages/brace-ec/src/operator/mutator/mod.rs
+++ b/packages/brace-ec/src/operator/mutator/mod.rs
@@ -127,3 +127,17 @@ where
         (**self).dyn_mutate(individual, &mut rng)
     }
 }
+
+impl<I, E> Mutator<I> for Box<dyn DynMutator<I, E> + Send + Sync>
+where
+    I: Individual,
+{
+    type Error = E;
+
+    fn mutate<Rng>(&self, individual: I, mut rng: &mut Rng) -> Result<I, Self::Error>
+    where
+        Rng: rand::Rng + ?Sized,
+    {
+        (**self).dyn_mutate(individual, &mut rng)
+    }
+}

--- a/packages/brace-ec/src/operator/recombinator/mod.rs
+++ b/packages/brace-ec/src/operator/recombinator/mod.rs
@@ -102,3 +102,19 @@ where
         (**self).dyn_recombine(population, &mut rng)
     }
 }
+
+impl<P, O, E> Recombinator<P> for Box<dyn DynRecombinator<P, O, E> + Send + Sync>
+where
+    P: Population,
+    O: Population<Individual = P::Individual>,
+{
+    type Output = O;
+    type Error = E;
+
+    fn recombine<Rng>(&self, population: P, mut rng: &mut Rng) -> Result<Self::Output, Self::Error>
+    where
+        Rng: rand::Rng + ?Sized,
+    {
+        (**self).dyn_recombine(population, &mut rng)
+    }
+}

--- a/packages/brace-ec/src/operator/selector/mod.rs
+++ b/packages/brace-ec/src/operator/selector/mod.rs
@@ -209,3 +209,19 @@ where
         (**self).dyn_select(population, &mut rng)
     }
 }
+
+impl<P, O, E> Selector<P> for Box<dyn DynSelector<P, O, E> + Send + Sync>
+where
+    P: Population + ?Sized,
+    O: Population<Individual = P::Individual>,
+{
+    type Output = O;
+    type Error = E;
+
+    fn select<Rng>(&self, population: &P, mut rng: &mut Rng) -> Result<Self::Output, Self::Error>
+    where
+        Rng: rand::Rng + ?Sized,
+    {
+        (**self).dyn_select(population, &mut rng)
+    }
+}


### PR DESCRIPTION
This is a follow-up to #56 that implements the various operator traits for `Box` with `Send + Sync` marker traits.

The dyn-compatible operator traits were previously introduced to support operators such as `Weighted` which required boxed trait objects to compose different operators together. The standard operator traits were then implemented for the boxed trait objects. However, trait objets with different marker traits are considered a separate type so there would need to be a new implementation for each combination of marker traits.

This change simply implements the operator traits for the boxed dyn-compatible operator traits with the `Send` and `Sync` bounds.