### PR TITLE
Update `Weighted` operator to require `Send + Sync`

### DIFF
--- a/packages/brace-ec/src/operator/weighted.rs
+++ b/packages/brace-ec/src/operator/weighted.rs
@@ -20,14 +20,14 @@ where
     operators: Vec<(Box<T>, u64)>,
 }
 
-impl<P, O> Weighted<dyn DynSelector<P, O>>
+impl<P, O> Weighted<dyn DynSelector<P, O> + Send + Sync>
 where
     P: Population + ?Sized,
     O: Population<Individual = P::Individual>,
 {
     pub fn selector<S>(selector: S, weight: u64) -> Self
     where
-        S: Selector<P, Output = O, Error: Error + Send + Sync + 'static> + 'static,
+        S: Selector<P, Output = O, Error: Error + Send + Sync + 'static> + Send + Sync + 'static,
     {
         Self {
             operators: vec![(Box::new(selector), weight)],
@@ -36,14 +36,17 @@ where
 
     pub fn with_selector<S>(mut self, selector: S, weight: u64) -> Self
     where
-        S: Selector<P, Output: Into<O>, Error: Error + Send + Sync + 'static> + 'static,
+        S: Selector<P, Output: Into<O>, Error: Error + Send + Sync + 'static>
+            + Send
+            + Sync
+            + 'static,
     {
         self.operators.push((Box::new(selector), weight));
         self
     }
 }
 
-impl<P, O> Selector<P> for Weighted<dyn DynSelector<P, O>>
+impl<P, O> Selector<P> for Weighted<dyn DynSelector<P, O> + Send + Sync>
 where
     P: Population,
     O: Population<Individual = P::Individual>,
@@ -64,13 +67,13 @@ where
     }
 }
 
-impl<I> Weighted<dyn DynMutator<I>>
+impl<I> Weighted<dyn DynMutator<I> + Send + Sync>
 where
     I: Individual,
 {
     pub fn mutator<M>(mutator: M, weight: u64) -> Self
     where
-        M: Mutator<I, Error: Error + Send + Sync + 'static> + 'static,
+        M: Mutator<I, Error: Error + Send + Sync + 'static> + Send + Sync + 'static,
     {
         Self {
             operators: vec![(Box::new(mutator), weight)],
@@ -79,14 +82,14 @@ where
 
     pub fn with_mutator<M>(mut self, mutator: M, weight: u64) -> Self
     where
-        M: Mutator<I, Error: Error + Send + Sync + 'static> + 'static,
+        M: Mutator<I, Error: Error + Send + Sync + 'static> + Send + Sync + 'static,
     {
         self.operators.push((Box::new(mutator), weight));
         self
     }
 }
 
-impl<I> Mutator<I> for Weighted<dyn DynMutator<I>>
+impl<I> Mutator<I> for Weighted<dyn DynMutator<I> + Send + Sync>
 where
     I: Individual,
 {
@@ -105,14 +108,17 @@ where
     }
 }
 
-impl<P, O> Weighted<dyn DynRecombinator<P, O>>
+impl<P, O> Weighted<dyn DynRecombinator<P, O> + Send + Sync>
 where
     P: Population,
     O: Population<Individual = P::Individual>,
 {
     pub fn recombinator<R>(recombinator: R, weight: u64) -> Self
     where
-        R: Recombinator<P, Output = O, Error: Error + Send + Sync + 'static> + 'static,
+        R: Recombinator<P, Output = O, Error: Error + Send + Sync + 'static>
+            + Send
+            + Sync
+            + 'static,
     {
         Self {
             operators: vec![(Box::new(recombinator), weight)],
@@ -121,14 +127,17 @@ where
 
     pub fn with_recombinator<R>(mut self, recombinator: R, weight: u64) -> Self
     where
-        R: Recombinator<P, Output: Into<O>, Error: Error + Send + Sync + 'static> + 'static,
+        R: Recombinator<P, Output: Into<O>, Error: Error + Send + Sync + 'static>
+            + Send
+            + Sync
+            + 'static,
     {
         self.operators.push((Box::new(recombinator), weight));
         self
     }
 }
 
-impl<P, O> Recombinator<P> for Weighted<dyn DynRecombinator<P, O>>
+impl<P, O> Recombinator<P> for Weighted<dyn DynRecombinator<P, O> + Send + Sync>
 where
     P: Population,
     O: Population<Individual = P::Individual>,
@@ -149,13 +158,13 @@ where
     }
 }
 
-impl<G> Weighted<dyn DynEvolver<G>>
+impl<G> Weighted<dyn DynEvolver<G> + Send + Sync>
 where
     G: Generation,
 {
     pub fn evolver<E>(evolver: E, weight: u64) -> Self
     where
-        E: Evolver<G, Error: Error + Send + Sync + 'static> + 'static,
+        E: Evolver<G, Error: Error + Send + Sync + 'static> + Send + Sync + 'static,
     {
         Self {
             operators: vec![(Box::new(evolver), weight)],
@@ -164,14 +173,14 @@ where
 
     pub fn with_evolver<M>(mut self, evolver: M, weight: u64) -> Self
     where
-        M: Evolver<G, Error: Error + Send + Sync + 'static> + 'static,
+        M: Evolver<G, Error: Error + Send + Sync + 'static> + Send + Sync + 'static,
     {
         self.operators.push((Box::new(evolver), weight));
         self
     }
 }
 
-impl<G> Evolver<G> for Weighted<dyn DynEvolver<G>>
+impl<G> Evolver<G> for Weighted<dyn DynEvolver<G> + Send + Sync>
 where
     G: Generation,
 {
@@ -190,13 +199,13 @@ where
     }
 }
 
-impl<I> Weighted<dyn DynEvaluator<I>>
+impl<I> Weighted<dyn DynEvaluator<I> + Send + Sync>
 where
     I: Individual,
 {
     pub fn evaluator<S>(evaluator: S, weight: u64) -> Self
     where
-        S: Evaluator<I, Error: Error + Send + Sync + 'static> + 'static,
+        S: Evaluator<I, Error: Error + Send + Sync + 'static> + Send + Sync + 'static,
     {
         Self {
             operators: vec![(Box::new(evaluator), weight)],
@@ -205,14 +214,14 @@ where
 
     pub fn with_evaluator<S>(mut self, evaluator: S, weight: u64) -> Self
     where
-        S: Evaluator<I, Error: Error + Send + Sync + 'static> + 'static,
+        S: Evaluator<I, Error: Error + Send + Sync + 'static> + Send + Sync + 'static,
     {
         self.operators.push((Box::new(evaluator), weight));
         self
     }
 }
 
-impl<I> Evaluator<I> for Weighted<dyn DynEvaluator<I>>
+impl<I> Evaluator<I> for Weighted<dyn DynEvaluator<I> + Send + Sync>
 where
     I: Individual,
 {
@@ -231,10 +240,10 @@ where
     }
 }
 
-impl<T> Weighted<dyn DynGenerator<T>> {
+impl<T> Weighted<dyn DynGenerator<T> + Send + Sync> {
     pub fn generator<G>(generator: G, weight: u64) -> Self
     where
-        G: Generator<T, Error: Error + Send + Sync + 'static> + 'static,
+        G: Generator<T, Error: Error + Send + Sync + 'static> + Send + Sync + 'static,
     {
         Self {
             operators: vec![(Box::new(generator), weight)],
@@ -243,14 +252,14 @@ impl<T> Weighted<dyn DynGenerator<T>> {
 
     pub fn with_generator<G>(mut self, generator: G, weight: u64) -> Self
     where
-        G: Generator<T, Error: Error + Send + Sync + 'static> + 'static,
+        G: Generator<T, Error: Error + Send + Sync + 'static> + Send + Sync + 'static,
     {
         self.operators.push((Box::new(generator), weight));
         self
     }
 }
 
-impl<T> Generator<T> for Weighted<dyn DynGenerator<T>> {
+impl<T> Generator<T> for Weighted<dyn DynGenerator<T> + Send + Sync> {
     type Error = WeightedError;
 
     fn generate<Rng>(&self, rng: &mut Rng) -> Result<T, Self::Error>


### PR DESCRIPTION
This updates the `Weighted` operator to require component operators to implement the `Send` and `Sync` marker traits.

The `Weighted` operator is useful but unfortunately cannot be used with the parallel operators as it is not `Send + Sync`. By adding the `Send + Sync` bounds to the boxed trait object and the component operators it will be possible to use parallel operators, at the expense of ruling out operators that are not `Send + Sync` such as those without thread-safe interior mutability. As the project has a number of the former but none of the latter this seems like the best option.

This change simply updates the boxed trait object inside `Weighted` with the `Send + Sync` bounds from #126, and updates the constructor functions and builder methods to also add this bound. It would have been possible to add the `Send + Sync` option as a separate implementation but that would require separate functions/methods and potentially be more confusing to users. If any non-send/sync operators are added later then this can be added.