### PR TITLE
Add operator `twice` methods

### DIFF
--- a/packages/brace-ec/src/operator/evolver/mod.rs
+++ b/packages/brace-ec/src/operator/evolver/mod.rs
@@ -59,6 +59,10 @@ where
         RepeatN::new(self)
     }
 
+    fn twice(self) -> RepeatN<2, Self> {
+        self.repeat_n()
+    }
+
     fn limit(self, generation: G::Id) -> Limit<G, Self> {
         Limit::new(self, generation)
     }

--- a/packages/brace-ec/src/operator/mutator/mod.rs
+++ b/packages/brace-ec/src/operator/mutator/mod.rs
@@ -65,6 +65,10 @@ where
         RepeatN::new(self)
     }
 
+    fn twice(self) -> RepeatN<2, Self> {
+        self.repeat_n()
+    }
+
     fn each<I>(self) -> Each<Self, I>
     where
         I: Individual<Genome: IterableMut<Item = T>>,

--- a/packages/brace-ec/src/operator/recombinator/mod.rs
+++ b/packages/brace-ec/src/operator/recombinator/mod.rs
@@ -55,6 +55,10 @@ where
         RepeatN::new(self)
     }
 
+    fn twice(self) -> RepeatN<2, Self> {
+        self.repeat_n()
+    }
+
     fn inspect<F>(self, inspector: F) -> Inspect<Self, F>
     where
         F: Fn(&Self::Output),

--- a/packages/brace-ec/src/operator/selector/mod.rs
+++ b/packages/brace-ec/src/operator/selector/mod.rs
@@ -164,6 +164,10 @@ where
         RepeatN::new(self)
     }
 
+    fn twice(self) -> RepeatN<2, Self> {
+        self.repeat_n()
+    }
+
     fn inspect<F>(self, inspector: F) -> Inspect<Self, F>
     where
         F: Fn(&Self::Output),


### PR DESCRIPTION
This adds a new `twice` method to the operator traits.

The `RepeatN` operator adapter was added in #125 and provided the ability to repeat the operator using a const generic, but the turbofish syntax is not ideal for users who are more familiar with Evolutionary Computation than Rust. As this project wants to support everyone and simplify the operator pipeline there should be an alias for certain repetitions.

This change introduces a new `twice` method on the `Evolver`, `Mutator`, `Recombinator` and `Selector` operator traits that is simply an alias to `repeat_n::<2>()`. This allows users to avoid the turbofish syntax for the simple case of repeating an operator twice. This is mainly beneficial to selectors as the alternative `repeat(2)` would produce a different output.