### PR TITLE
Add `Selector::reproduce` method

### DIFF
--- a/packages/brace-ec/src/operator/selector/mod.rs
+++ b/packages/brace-ec/src/operator/selector/mod.rs
@@ -62,6 +62,13 @@ where
         Recombine::new(self, recombinator)
     }
 
+    fn reproduce<R>(self, recombinator: R) -> Take<Recombine<Self, R>, 1>
+    where
+        R: Recombinator<Self::Output>,
+    {
+        Take::new(Recombine::new(self, recombinator))
+    }
+
     fn evaluate<S>(self, evaluator: S) -> Evaluate<Self, S>
     where
         S: Evaluator<P::Individual>,


### PR DESCRIPTION
This adds a new `reproduce` method to the `Selector` trait.

The `Recombinator` trait allows multiple parent individuals to be recombined into multiple output individuals. In the case of the various crossover recombinators, genes are swapped between the two parents and then both modified parents are returned. However, more often than not it is only one of the output individuals that is actually wanted. The `Take` operator adapter exists to support this but that would require the use of the turbofish syntax which not all users may be familiar with.

This change adds a new `reproduce` method to the `Selector` trait that is simply an alias to `.recombine(r).take::<1>()`.