### PR TITLE
Implement population traits for `Evaluated` individual

### DIFF
--- a/packages/brace-ec/src/individual/evaluated.rs
+++ b/packages/brace-ec/src/individual/evaluated.rs
@@ -46,12 +46,12 @@ where
 
 impl<T, S> Population for Evaluated<T, S>
 where
-    T: Population,
+    T: Individual<Genome: Population>,
 {
-    type Individual = T::Individual;
+    type Individual = <T::Genome as Population>::Individual;
 
     fn len(&self) -> usize {
-        self.individual.len()
+        self.individual.genome().len()
     }
 }
 

--- a/packages/brace-ec/src/individual/evaluated.rs
+++ b/packages/brace-ec/src/individual/evaluated.rs
@@ -1,4 +1,6 @@
 use crate::fitness::Fitness;
+use crate::population::Population;
+use crate::util::iter::TryFromIterator;
 
 use super::Individual;
 
@@ -39,6 +41,41 @@ where
 
     fn fitness_mut(&mut self) -> &mut Self::Fitness {
         &mut self.fitness
+    }
+}
+
+impl<T, S> Population for Evaluated<T, S>
+where
+    T: Population,
+{
+    type Individual = T::Individual;
+
+    fn len(&self) -> usize {
+        self.individual.len()
+    }
+}
+
+impl<U, T, S> AsRef<U> for Evaluated<T, S>
+where
+    T: AsRef<U>,
+{
+    fn as_ref(&self) -> &U {
+        self.individual.as_ref()
+    }
+}
+
+impl<U, T, S> TryFromIterator<U> for Evaluated<T, S>
+where
+    T: TryFromIterator<U>,
+    S: Fitness,
+{
+    type Error = T::Error;
+
+    fn try_from_iter<I>(iter: I) -> Result<Self, Self::Error>
+    where
+        I: IntoIterator<Item = U>,
+    {
+        T::try_from_iter(iter).map(Self::from)
     }
 }
 

--- a/packages/brace-ec/src/individual/evaluated.rs
+++ b/packages/brace-ec/src/individual/evaluated.rs
@@ -55,15 +55,6 @@ where
     }
 }
 
-impl<U, T, S> AsRef<U> for Evaluated<T, S>
-where
-    T: AsRef<U>,
-{
-    fn as_ref(&self) -> &U {
-        self.individual.as_ref()
-    }
-}
-
 impl<U, T, S> TryFromIterator<U> for Evaluated<T, S>
 where
     T: TryFromIterator<U>,


### PR DESCRIPTION
This implements additional traits for the `Evaluated` individual type.

The `Evaluated` individual, previously called `Scored`, was introduced as the default way to associated any individual with a separate fitness value. This allows users to use this type instead of writing a custom implementation of `Individual` which may need many different trait implementations to support all of the different operators. However, even `Evaluated` does not implement enough traits to be used everywhere. In particular it cannot be used with `Generator::populate` because although the inner genome may be a population the individual itself is not.

This change introduces new trait implementations for the `Evaluated` type to support the `Populate` generator. Specifically, this implements both `Population` and `TryFromIterator`. Various individuals such as `Vec` already implement both `Individual` and `Population` so this isn't anything new. The type is still primarily an individual but as the `Population` trait is used in place of a generic `Collection` trait it needs the implementation. The `TryFromIterator` trait is also a requirement of the `Populate` generator so it is also implemented.