### PR TITLE
Add `hiff` example package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,6 +590,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hiff"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "brace-ec",
+ "brace-ec-tui",
+ "clap",
+ "rand 0.9.0",
+ "ratatui",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/hiff/Cargo.toml
+++ b/examples/hiff/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "hiff"
+version = "0.0.0"
+license = "MIT OR Apache-2.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = "1.0.95"
+brace-ec = { path = "../../packages/brace-ec" }
+brace-ec-tui = { path = "../../packages/brace-ec-tui" }
+clap = { version = "4.5.26", features = ["derive"] }
+rand = "0.9.0"
+ratatui = "0.29.0"

--- a/examples/hiff/src/args.rs
+++ b/examples/hiff/src/args.rs
@@ -1,0 +1,24 @@
+use clap::Parser;
+
+#[derive(Parser)]
+pub struct Args {
+    /// The population size.
+    #[arg(long, default_value_t = 100)]
+    pub population: usize,
+
+    /// The number of bits in a bitstring.
+    #[arg(long, default_value_t = 128)]
+    pub bits: usize,
+
+    /// The number of generations.
+    #[arg(long, default_value_t = 100)]
+    pub generations: usize,
+
+    /// Visualize the best individual.
+    #[arg(long)]
+    pub visualize: bool,
+
+    /// Enable parallel selection.
+    #[arg(long)]
+    pub parallel: bool,
+}

--- a/examples/hiff/src/main.rs
+++ b/examples/hiff/src/main.rs
@@ -1,0 +1,94 @@
+pub mod args;
+pub mod renderer;
+
+use std::io::Write;
+
+use anyhow::Error;
+use brace_ec::fitness::summed::Summed;
+use brace_ec::generation::Generation;
+use brace_ec::individual::evaluated::Evaluated;
+use brace_ec::individual::Individual;
+use brace_ec::operator::evaluator::hiff::Hiff;
+use brace_ec::operator::evolver::Evolver;
+use brace_ec::operator::generator::random::Random;
+use brace_ec::operator::generator::Generator;
+use brace_ec::operator::mutator::invert::Invert;
+use brace_ec::operator::mutator::Mutator;
+use brace_ec::operator::recombinator::point::TwoPointCrossover;
+use brace_ec::operator::selector::best::Best;
+use brace_ec::operator::selector::lexicase::Lexicase;
+use brace_ec::operator::selector::tournament::Tournament;
+use brace_ec::operator::selector::Selector;
+use brace_ec::operator::weighted::Weighted;
+use brace_ec::operator::IntoParallelOperator;
+use brace_ec::population::Population;
+use brace_ec_tui::evolver::Terminal;
+use clap::Parser;
+
+use self::args::Args;
+use self::renderer::HiffRenderer;
+
+type Ind = Evaluated<Vec<bool>, Summed<Vec<usize>>>;
+type Pop = Vec<Ind>;
+
+fn main() -> Result<(), Error> {
+    let args = Args::parse();
+
+    let mut rng = rand::rng();
+
+    let population: Pop = Random::bernoulli(0.5)
+        .populate(args.bits)
+        .evaluate(Hiff)
+        .populate(args.population)
+        .generate(&mut rng)?;
+
+    let selector = Weighted::selector(Best, 1)
+        .with_selector(Lexicase, 5)
+        .with_selector(Tournament::binary(), args.population as u64 - 1)
+        .twice() // ICE: .repeat(2).take::<2>()
+        .reproduce(TwoPointCrossover)
+        .mutate(Invert.each_reciprocal_rate())
+        .evaluate(Hiff)
+        .fill()
+        .parallel_if(args.parallel);
+
+    if args.visualize {
+        Terminal::new(
+            selector.evolver().limit(args.generations as u64),
+            HiffRenderer,
+        )
+        .evolve((0, population), &mut rng)?;
+    } else {
+        let generation = (0, population);
+
+        print_best(&generation);
+
+        selector
+            .evolver()
+            .inspect(print_best)
+            .repeat(args.generations)
+            .evolve(generation, &mut rng)?;
+    }
+
+    Ok(())
+}
+
+fn print_best(generation: &(u64, Pop)) {
+    let [best] = generation.population().select(Best).unwrap();
+
+    let mut stdout = std::io::stdout().lock();
+
+    writeln!(
+        stdout,
+        "Generation = {}, Fitness = {}, Genome =",
+        generation.id(),
+        best.fitness().total()
+    )
+    .ok();
+
+    for &bit in best.genome() {
+        write!(stdout, " {}", bit as u8).ok();
+    }
+
+    writeln!(stdout).ok();
+}

--- a/examples/hiff/src/renderer.rs
+++ b/examples/hiff/src/renderer.rs
@@ -1,0 +1,55 @@
+use brace_ec::generation::Generation;
+use brace_ec::individual::Individual;
+use brace_ec::operator::selector::best::Best;
+use brace_ec::population::Population;
+use brace_ec_tui::renderer::Renderer;
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Position, Rect};
+use ratatui::style::Color;
+use ratatui::text::Text;
+use ratatui::widgets::Widget;
+use ratatui::Frame;
+
+use super::{Ind, Pop};
+
+pub struct HiffRenderer;
+
+impl Renderer<(u64, Pop)> for HiffRenderer {
+    fn render(&self, generation: &(u64, Pop), frame: &mut Frame) {
+        let [best] = generation.population().select(Best).unwrap();
+
+        let help = Text::from("P = Pause, Esc = Exit").left_aligned();
+        let title = Text::from("Best Individual").centered();
+        let info = Text::from(format!(
+            "Fitness = {}, Generation = {}",
+            best.fitness().total(),
+            generation.id()
+        ))
+        .right_aligned();
+
+        frame.render_widget(help, frame.area());
+        frame.render_widget(title, frame.area());
+        frame.render_widget(info, frame.area());
+        frame.render_widget(HiffWidget(best), frame.area());
+    }
+}
+
+pub struct HiffWidget(Ind);
+
+impl Widget for HiffWidget {
+    fn render(self, _: Rect, buf: &mut Buffer)
+    where
+        Self: Sized,
+    {
+        for (i, val) in self.0.genome().iter().take(buf.content.len()).enumerate() {
+            let (x, y) = buf.pos_of(i);
+
+            let color = match val {
+                true => Color::White,
+                false => Color::Black,
+            };
+
+            buf[Position::new(x, y + 1)].set_char('█').set_fg(color);
+        }
+    }
+}


### PR DESCRIPTION
This adds a new `hiff` example package.

The project is at a sufficient point where real-world examples can be produced that make full use of the library. These should assist users with building their own systems while ensuring that the library works as expected.

This change introduces a new `hiff` example as a full package in the top-level `examples` directory. This makes use of generators, the `Weighted` selector, the `TwoPointCrossover` recombinator, the `Invert` and `EachReciprocalRate` mutators and the `Hiff` evaluator. This also demonstrates the usage of `parallel_if` to conditionally use the `Fill` or `ParFill` evolvers via `Either`. The command-line options include the ability to swap between printing to the terminal and a full terminal user interface via the `visualize` flag. The example is not perfect but is a good demonstration.

This required a lot of new features to be implemented but the only one that wasn't initially anticipated was the `RepeatN` operator. Adding this and the `twice` method worked out in the end but the reason for inclusion at this time was due to an unexpected Internal Compiler Error (ICE).

Unfortunately, during development a compiler error was returned under certain conditions. It currently appears to be triggered when using the selector with the `Repeat` adapter. This required the use of the `Take` adapter to support the crossover recombinator but simply swapping `repeat` out with `repeat_n` resolved the issue, even when needlessly using `take`. This will require further investigation as the ICE occurs on stable, beta and nightly so there is no immediate fix.